### PR TITLE
Support additional parameters when creating users

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/AssignmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentImpl.java
@@ -60,8 +60,8 @@ public class AssignmentImpl extends BaseImpl<Assignment, AssignmentReader, Assig
 
     @Override
     public Optional<Assignment> deleteAssignment(String courseId, String assignmentId) throws IOException {
-        Map<String, String> postParams = new HashMap<>();
-        postParams.put("event", "delete");
+        Map<String, List<String>> postParams = new HashMap<>();
+        postParams.put("event", Collections.singletonList("delete"));
         String createdUrl = buildCanvasUrl("courses/" + courseId + "/assignments/" + assignmentId, Collections.emptyMap());
         Response response = canvasMessenger.deleteFromCanvas(oauthToken, createdUrl, postParams);
         LOG.debug("response " + response.toString());

--- a/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
@@ -62,8 +62,8 @@ public class CourseImpl extends BaseImpl<Course, CourseReader, CourseWriter> imp
 
     @Override
     public Boolean deleteCourse(String courseId) throws IOException {
-        Map<String,String> postParams = new HashMap<>();
-        postParams.put("event", "delete");
+        Map<String, List<String>> postParams = new HashMap<>();
+        postParams.put("event", Collections.singletonList("delete"));
         String createdUrl = buildCanvasUrl("courses/" + courseId, Collections.emptyMap());
         Response response = canvasMessenger.deleteFromCanvas(oauthToken, createdUrl, postParams);
         LOG.debug("response "+ response.toString());

--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
@@ -48,8 +48,8 @@ public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, Enrol
 
     @Override
     public Optional<Enrollment> enrollUser(String courseId, String userId) throws InvalidOauthTokenException, IOException {
-        Map<String,String> courseMap = new HashMap<>();
-        courseMap.put("enrollment[user_id]", String.valueOf(userId));
+        Map<String, List<String>> courseMap = new HashMap<>();
+        courseMap.put("enrollment[user_id]", Collections.singletonList(String.valueOf(userId)));
         String createdUrl = buildCanvasUrl("courses/" + courseId + "/enrollments", Collections.emptyMap());
         LOG.debug("create URl for course enrollments: "+ createdUrl);
         Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, courseMap);
@@ -62,8 +62,8 @@ public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, Enrol
 
     @Override
     public Optional<Enrollment> dropUser(String courseId, String enrollmentId) throws InvalidOauthTokenException, IOException {
-        Map<String,String> postParams = new HashMap<>();
-        postParams.put("task", "delete");
+        Map<String, List<String>> postParams = new HashMap<>();
+        postParams.put("task", Collections.singletonList("delete"));
         String createdUrl = buildCanvasUrl("courses/" + courseId + "/enrollments/" + enrollmentId, Collections.emptyMap());
         LOG.debug("create URl for course enrollments: "+ createdUrl);
         Response response = canvasMessenger.deleteFromCanvas(oauthToken, createdUrl, postParams);

--- a/src/main/java/edu/ksu/canvas/impl/RestCanvasMessenger.java
+++ b/src/main/java/edu/ksu/canvas/impl/RestCanvasMessenger.java
@@ -60,7 +60,7 @@ public class RestCanvasMessenger implements CanvasMessenger {
     }
 
     @Override
-    public Response sendToCanvas(@NotNull OauthToken oauthToken, @NotNull String url, @NotNull Map<String,String> parameters) throws InvalidOauthTokenException, IOException {
+    public Response sendToCanvas(@NotNull OauthToken oauthToken, @NotNull String url, @NotNull Map<String, List<String>> parameters) throws InvalidOauthTokenException, IOException {
         final Response response = restClient.sendApiPost(oauthToken, url, parameters, connectTimeout, readTimeout);
         if (response.getResponseCode() == 401) {
             throw new InvalidOauthTokenException();
@@ -87,7 +87,7 @@ public class RestCanvasMessenger implements CanvasMessenger {
     }
 
     @Override
-    public Response deleteFromCanvas(@NotNull OauthToken oauthToken, @NotNull String url, @NotNull Map<String,String> parameters) throws InvalidOauthTokenException, IOException {
+    public Response deleteFromCanvas(@NotNull OauthToken oauthToken, @NotNull String url, @NotNull Map<String, List<String>> parameters) throws InvalidOauthTokenException, IOException {
         final Response response = restClient.sendApiDelete(oauthToken, url, parameters, connectTimeout, readTimeout);
         if (response.getResponseCode() == 401) {
             throw new InvalidOauthTokenException();
@@ -96,7 +96,7 @@ public class RestCanvasMessenger implements CanvasMessenger {
     }
 
     @Override
-    public Response putToCanvas(@NotNull OauthToken oauthToken, @NotNull String url, @NotNull Map<String,Object> parameters) throws InvalidOauthTokenException, IOException {
+    public Response putToCanvas(@NotNull OauthToken oauthToken, @NotNull String url, @NotNull Map<String, List<String>> parameters) throws InvalidOauthTokenException, IOException {
         final Response response = restClient.sendApiPut(oauthToken, url, parameters, connectTimeout, readTimeout);
         if (response.getResponseCode() == 401) {
             throw new InvalidOauthTokenException();

--- a/src/main/java/edu/ksu/canvas/impl/UserImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/UserImpl.java
@@ -27,12 +27,9 @@ public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements 
 
     @Override
     public Optional<User> createUser(User user) throws InvalidOauthTokenException, IOException {
-        Map<String, List<String>> postParameters = new HashMap<>();
-        postParameters.put("name", Collections.singletonList(user.getName()));
-        postParameters.put("pseudonym[unique_id]", Collections.singletonList(user.getLoginId()));
-        String createdUrl = buildCanvasUrl( "accounts/" +CanvasConstants.ACCOUNT_ID + "/users", Collections.emptyMap());
+        String createdUrl = buildCanvasUrl( "accounts/" + CanvasConstants.ACCOUNT_ID + "/users", Collections.emptyMap());
         LOG.debug("create URl for user creation : "+ createdUrl);
-        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, postParameters);
+        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, user.toPostMap());
         if (response.getErrorHappened() || ( response.getResponseCode() != 200)) {
             LOG.debug("Failed to create user, error message: " + response.toString());
             return Optional.empty();

--- a/src/main/java/edu/ksu/canvas/impl/UserImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/UserImpl.java
@@ -27,9 +27,9 @@ public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements 
 
     @Override
     public Optional<User> createUser(User user) throws InvalidOauthTokenException, IOException {
-        Map<String, String> postParameters = new HashMap<>();
-        postParameters.put("name", user.getName());
-        postParameters.put("pseudonym[unique_id]", user.getLoginId());
+        Map<String, List<String>> postParameters = new HashMap<>();
+        postParameters.put("name", Collections.singletonList(user.getName()));
+        postParameters.put("pseudonym[unique_id]", Collections.singletonList(user.getLoginId()));
         String createdUrl = buildCanvasUrl( "accounts/" +CanvasConstants.ACCOUNT_ID + "/users", Collections.emptyMap());
         LOG.debug("create URl for user creation : "+ createdUrl);
         Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, postParameters);
@@ -42,9 +42,9 @@ public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements 
 
     @Override
     public Optional<User> updateUser(User user) throws InvalidOauthTokenException, IOException {
-        Map<String, String> postParameters = new HashMap<>();
-        postParameters.put("name", user.getName());
-        postParameters.put("pseudonym[unique_id]", user.getLoginId());
+        Map<String, List<String>> postParameters = new HashMap<>();
+        postParameters.put("name", Collections.singletonList(user.getName()));
+        postParameters.put("pseudonym[unique_id]", Collections.singletonList(user.getLoginId()));
         String createdUrl = buildCanvasUrl("accounts/" + String.valueOf(user.getId()) + "/users", Collections.emptyMap());
         LOG.debug("create URl for user creation : " + createdUrl);
         Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, postParameters);

--- a/src/main/java/edu/ksu/canvas/interfaces/CanvasMessenger.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/CanvasMessenger.java
@@ -15,10 +15,10 @@ public interface CanvasMessenger {
     List<Response> getFromCanvas(OauthToken oauthToken, String url) throws InvalidOauthTokenException, IOException;
     List<Response> getFromCanvas(OauthToken oauthToken, String url, Consumer<Response> consumer) throws InvalidOauthTokenException, IOException;
     //TODO: Should probably make this parameter list more sane
-    Response sendToCanvas(OauthToken oauthToken, String url, Map<String, String> parameters) throws InvalidOauthTokenException, IOException;
+    Response sendToCanvas(OauthToken oauthToken, String url, Map<String, List<String>> parameters) throws InvalidOauthTokenException, IOException;
     Response sendJsonPostToCanvas(OauthToken oauthToken, String url, JsonObject requestBody) throws InvalidOauthTokenException, IOException;
     Response sendJsonPutToCanvas(OauthToken oauthToken, String url, JsonObject requestBody) throws InvalidOauthTokenException, IOException;
-    Response deleteFromCanvas(OauthToken oauthToken, String url, Map<String,String> parameters) throws InvalidOauthTokenException, IOException;
+    Response deleteFromCanvas(OauthToken oauthToken, String url, Map<String, List<String>> parameters) throws InvalidOauthTokenException, IOException;
     Response getSingleResponseFromCanvas(OauthToken oauthToken, String url) throws InvalidOauthTokenException, IOException;
-    Response putToCanvas(OauthToken oauthToken, String url, Map<String, Object> parameters) throws InvalidOauthTokenException, IOException;
+    Response putToCanvas(OauthToken oauthToken, String url, Map<String, List<String>> parameters) throws InvalidOauthTokenException, IOException;
 }

--- a/src/main/java/edu/ksu/canvas/model/User.java
+++ b/src/main/java/edu/ksu/canvas/model/User.java
@@ -21,6 +21,7 @@ public class User extends BaseCanvasModel implements Serializable {
     private String sisUserId;
     private String sisImportId;
     private String loginId;
+    private String integrationId;
     private String avatarUrl;
     private List<Enrollment> enrollments;
     private String email;
@@ -81,12 +82,22 @@ public class User extends BaseCanvasModel implements Serializable {
         this.sisImportId = sisImportId;
     }
 
+    @CanvasField(overrideObjectKey = "pseudonym", postKey = "unique_id")
     public String getLoginId() {
         return loginId;
     }
 
     public void setLoginId(String loginId) {
         this.loginId = loginId;
+    }
+
+    @CanvasField(overrideObjectKey = "pseudonym", postKey = "integration_id")
+    public String getIntegrationId() {
+        return integrationId;
+    }
+
+    public void setIntegrationId(final String integrationId) {
+        this.integrationId = integrationId;
     }
 
     @CanvasField(postKey = "avatar][url")

--- a/src/main/java/edu/ksu/canvas/net/RefreshingRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/RefreshingRestClient.java
@@ -6,6 +6,7 @@ import org.apache.log4j.Logger;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 public class RefreshingRestClient implements RestClient {
@@ -46,7 +47,7 @@ public class RefreshingRestClient implements RestClient {
     }
 
     @Override
-    public Response sendApiPost(@NotNull OauthToken token, @NotNull String url, Map<String, String> postParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
+    public Response sendApiPost(@NotNull OauthToken token, @NotNull String url, Map<String, List<String>> postParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         try {
             return restClient.sendApiPost(token, url, postParameters, connectTimeout, readTimeout);
         } catch (InvalidOauthTokenException e) {
@@ -57,7 +58,7 @@ public class RefreshingRestClient implements RestClient {
     }
 
     @Override
-    public Response sendApiDelete(@NotNull OauthToken token, @NotNull String url, Map<String, String> deleteParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
+    public Response sendApiDelete(@NotNull OauthToken token, @NotNull String url, Map<String, List<String>> deleteParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         try {
             return restClient.sendApiDelete(token, url, deleteParameters, connectTimeout, readTimeout);
         } catch (InvalidOauthTokenException e) {
@@ -68,7 +69,7 @@ public class RefreshingRestClient implements RestClient {
     }
 
     @Override
-    public Response sendApiPut(@NotNull OauthToken token, @NotNull String url, Map<String, Object> putParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
+    public Response sendApiPut(@NotNull OauthToken token, @NotNull String url, Map<String, List<String>> putParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         try {
             return restClient.sendApiPut(token, url, putParameters, connectTimeout, readTimeout);
         } catch (InvalidOauthTokenException e) {

--- a/src/main/java/edu/ksu/canvas/net/RestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/RestClient.java
@@ -3,15 +3,17 @@ package edu.ksu.canvas.net;
 import edu.ksu.canvas.exception.InvalidOauthTokenException;
 import edu.ksu.canvas.oauth.OauthToken;
 
-import javax.validation.constraints.NotNull;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+
+import javax.validation.constraints.NotNull;
 
 public interface RestClient {
     Response sendApiGet(@NotNull OauthToken token, @NotNull String url, int connectTimeout, int readTimeout) throws IOException;
     Response sendJsonPost(@NotNull OauthToken token, @NotNull String url, String json, int connectTimeout, int readTimeout) throws IOException;
     Response sendJsonPut(@NotNull OauthToken token, @NotNull String url, String json, int connectTimeout, int readTimeout) throws IOException;
-    Response sendApiPost(@NotNull OauthToken token, @NotNull String url, Map<String, String> postParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException;
-    Response sendApiDelete(@NotNull OauthToken token, @NotNull String url, Map<String, String> deleteParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException;
-    Response sendApiPut(@NotNull OauthToken token, @NotNull String url, Map<String, Object> putParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException;
+    Response sendApiPost(@NotNull OauthToken token, @NotNull String url, Map<String, List<String>> postParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException;
+    Response sendApiDelete(@NotNull OauthToken token, @NotNull String url, Map<String, List<String>> deleteParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException;
+    Response sendApiPut(@NotNull OauthToken token, @NotNull String url, Map<String, List<String>> putParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException;
 }

--- a/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
@@ -125,7 +125,7 @@ public class SimpleRestClient implements RestClient {
     }
 
     @Override
-    public Response sendApiPost(OauthToken token, String url, Map<String, String> postParameters,
+    public Response sendApiPost(OauthToken token, String url, Map<String, List<String>> postParameters,
                                        int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         LOG.debug("Sending API POST request to URL: " + url);
         Response response = new Response();
@@ -133,14 +133,7 @@ public class SimpleRestClient implements RestClient {
         Long beginTime = System.currentTimeMillis();
         HttpPost httpPost = new HttpPost(url);
         httpPost.setHeader("Authorization", "Bearer" + " " + token.getAccessToken());
-        List<NameValuePair> params = new ArrayList<>();
-
-        if (postParameters != null) {
-            for (Map.Entry<String, String> entry : postParameters.entrySet()) {
-                params.add(new BasicNameValuePair(entry.getKey(),entry.getValue()));
-                LOG.debug("key "+ entry.getKey() +"\t value : "+ entry.getValue());
-            }
-        }
+        List<NameValuePair> params = convertParameters(postParameters);
 
         httpPost.setEntity(new UrlEncodedFormEntity(params));
         HttpResponse httpResponse =  httpClient.execute(httpPost);
@@ -154,7 +147,7 @@ public class SimpleRestClient implements RestClient {
     }
 
     @Override
-    public Response sendApiPut(OauthToken token, String url, Map<String, Object> putParameters,
+    public Response sendApiPut(OauthToken token, String url, Map<String, List<String>> putParameters,
                                 int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         LOG.debug("Sending API PUT request to URL: " + url);
         Response response = new Response();
@@ -162,14 +155,7 @@ public class SimpleRestClient implements RestClient {
         Long beginTime = System.currentTimeMillis();
         HttpPut httpPut = new HttpPut(url);
         httpPut.setHeader("Authorization", "Bearer" + " " + token.getAccessToken());
-        List<NameValuePair> params = new ArrayList<>();
-
-        if (putParameters != null) {
-            for (Map.Entry<String, Object> entry : putParameters.entrySet()) {
-                params.add(new BasicNameValuePair(entry.getKey(),entry.getValue().toString()));
-                LOG.debug("key "+ entry.getKey() +"\t value : "+ entry.getValue());
-            }
-        }
+        List<NameValuePair> params = convertParameters(putParameters);
 
         httpPut.setEntity(new UrlEncodedFormEntity(params));
         HttpResponse httpResponse =  httpClient.execute(httpPut);
@@ -184,7 +170,7 @@ public class SimpleRestClient implements RestClient {
 
 
     @Override
-    public Response sendApiDelete(OauthToken token, String url,Map<String, String> deleteParameters,
+    public Response sendApiDelete(OauthToken token, String url, Map<String, List<String>> deleteParameters,
                                        int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         LOG.debug("Sending API DELETE request to URL: " + url);
         Response response = new Response();
@@ -204,12 +190,8 @@ public class SimpleRestClient implements RestClient {
 
         httpDelete.setURI(URI.create(url));
         httpDelete.setHeader("Authorization", "Bearer" + " " + token.getAccessToken());
-        List<NameValuePair> params = new ArrayList<>();
-        if (deleteParameters != null) {
-            for (Map.Entry<String, String> entry : deleteParameters.entrySet()) {
-                params.add(new BasicNameValuePair(entry.getKey(),entry.getValue()));
-            }
-        }
+        List<NameValuePair> params = convertParameters(deleteParameters);
+
         httpDelete.setEntity(new UrlEncodedFormEntity(params));
         HttpResponse httpResponse = httpClient.execute(httpDelete);
 
@@ -255,6 +237,23 @@ public class SimpleRestClient implements RestClient {
         params.setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, connectTimeout);
         params.setParameter(CoreConnectionPNames.SO_TIMEOUT, readTimeout);
         return httpClient;
+    }
+
+    private static List<NameValuePair> convertParameters(final Map<String, List<String>> parameterMap) {
+        final List<NameValuePair> params = new ArrayList<>();
+
+        if (parameterMap == null) {
+            return params;
+        }
+
+        for (final Map.Entry<String, List<String>> param : parameterMap.entrySet()) {
+            final String key = param.getKey();
+            for (final String value : param.getValue()) {
+                params.add(new BasicNameValuePair(key, value));
+                LOG.debug("key "+ key +"\t value : " + value);
+            }
+        }
+        return params;
     }
 
 }

--- a/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
+++ b/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import java.util.List;
 import java.util.Map;
 
 public class BaseCanvasModelUTest {
@@ -27,10 +28,10 @@ public class BaseCanvasModelUTest {
         TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField1(FIELD1_VALUE);
 
-        Map<String, Object> postMap = canvasModel.toPostMap();
+        Map<String, List<String>> postMap = canvasModel.toPostMap();
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field1", postMap.containsKey(expectedKey));
-        Assert.assertEquals("Field1Value from canvasModel.toPostMap() did not have expected value for field1", FIELD1_VALUE, postMap.get(expectedKey));
+        Assert.assertArrayEquals("Field1Value from canvasModel.toPostMap() did not have expected value for field1", new String[] { FIELD1_VALUE }, postMap.get(expectedKey).toArray());
     }
 
     /* Make sure canvasFields with arrays = false are of form 'field' */
@@ -40,10 +41,10 @@ public class BaseCanvasModelUTest {
         TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField2(FIELD2_VALUE);
 
-        Map<String, Object> postMap = canvasModel.toPostMap();
+        Map<String, List<String>> postMap = canvasModel.toPostMap();
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field2", postMap.containsKey(expectedKey));
-        Assert.assertEquals("Field2Value from canvasModel.toPostMap() did not have expected value for field2", FIELD2_VALUE, postMap.get(expectedKey));
+        Assert.assertArrayEquals("Field2Value from canvasModel.toPostMap() did not have expected value for field2", new String[] { FIELD2_VALUE }, postMap.get(expectedKey).toArray());
     }
 
     /* Make sure canvasFields with arrays = true and an override key are of form override[field] */
@@ -53,10 +54,10 @@ public class BaseCanvasModelUTest {
         final TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField3(FIELD3_VALUE);
 
-        final Map<String, Object> postMap = canvasModel.toPostMap();
+        final Map<String, List<String>> postMap = canvasModel.toPostMap();
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field3", postMap.containsKey(expectedKey));
-        Assert.assertEquals("Field3Value from canvasModel.toPostMap() did not have expected value for field3", FIELD3_VALUE, postMap.get(expectedKey));
+        Assert.assertArrayEquals("Field3Value from canvasModel.toPostMap() did not have expected value for field3", new String[] { FIELD3_VALUE }, postMap.get(expectedKey).toArray());
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
+++ b/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
@@ -4,11 +4,13 @@ import edu.ksu.canvas.model.TestCanvasModel;
 import org.junit.Assert;
 import org.junit.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class BaseCanvasModelUTest {
     public static final String CLASS_POST_KEY = "test";
@@ -16,10 +18,13 @@ public class BaseCanvasModelUTest {
     public static final String FIELD1_POST_KEY = "field1Key";
     public static final String FIELD2_POST_KEY = "field2Key";
     public static final String FIELD3_POST_KEY = "field3Key";
+    public static final String FIELD4_POST_KEY = "field4Key";
+    public static final String FIELD5_POST_KEY = "field5Key";
     public static final String FIELD1_VALUE = "field1Value";
     public static final String FIELD2_VALUE = "field2Value";
     public static final String FIELD3_VALUE = "field3Value";
-
+    public static final Integer FIELD4_VALUE = 6789;
+    public static final List<Integer> FIELD5_VALUE = ImmutableList.of(1354, 9823, 5387);
 
     /* Make sure canvasFields with arrays = true are of form object[field] */
     @Test
@@ -58,6 +63,38 @@ public class BaseCanvasModelUTest {
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field3", postMap.containsKey(expectedKey));
         Assert.assertArrayEquals("Field3Value from canvasModel.toPostMap() did not have expected value for field3", new String[] { FIELD3_VALUE }, postMap.get(expectedKey).toArray());
+    }
+
+    @Test
+    public void postKeysAsArraysWithNonStringTypeSetCorrectly() throws Exception {
+        final String expectedKey = CLASS_POST_KEY + "[" + FIELD4_POST_KEY + "]";
+        final TestCanvasModel canvasModel = new TestCanvasModel();
+        canvasModel.setField4(FIELD4_VALUE);
+
+        final Map<String, List<String>> postMap = canvasModel.toPostMap();
+
+        Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field4", postMap.containsKey(expectedKey));
+        Assert.assertArrayEquals("Field3Value from canvasModel.toPostMap() did not have expected value for field4", new String[] { String.valueOf(FIELD4_VALUE) }, postMap.get(expectedKey).toArray());
+    }
+
+    @Test
+    public void postKeysAsArraysWithMultipleValuesSetCorrectly() throws Exception {
+        final String expectedKey = CLASS_POST_KEY + "[" + FIELD5_POST_KEY + "]";
+        final TestCanvasModel canvasModel = new TestCanvasModel();
+        canvasModel.setField5(FIELD5_VALUE);
+
+        final Map<String, List<String>> postMap = canvasModel.toPostMap();
+        final String[] expectedValue = FIELD5_VALUE.stream().map(String::valueOf).collect(Collectors.toList()).toArray(new String[] {});
+
+        Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field5", postMap.containsKey(expectedKey));
+        Assert.assertArrayEquals("Field3Value from canvasModel.toPostMap() did not have expected value for field5", expectedValue, postMap.get(expectedKey).toArray());
+    }
+
+    @Test
+    public void postKeysAsArraysContainsNoNullValues() throws Exception {
+        final TestCanvasModel canvasModel = new TestCanvasModel();
+        final Map<String, List<String>> postMap = canvasModel.toPostMap();
+        Assert.assertTrue("Result of canvasModel.toPostMap() is not empty as expected", postMap.isEmpty());
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
+++ b/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
@@ -11,10 +11,13 @@ import java.util.Map;
 
 public class BaseCanvasModelUTest {
     public static final String CLASS_POST_KEY = "test";
+    public static final String CLASS_POST_KEY_OVERRIDE = "override";
     public static final String FIELD1_POST_KEY = "field1Key";
     public static final String FIELD2_POST_KEY = "field2Key";
+    public static final String FIELD3_POST_KEY = "field3Key";
     public static final String FIELD1_VALUE = "field1Value";
     public static final String FIELD2_VALUE = "field2Value";
+    public static final String FIELD3_VALUE = "field3Value";
 
 
     /* Make sure canvasFields with arrays = true are of form object[field] */
@@ -41,6 +44,19 @@ public class BaseCanvasModelUTest {
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field2", postMap.containsKey(expectedKey));
         Assert.assertEquals("Field2Value from canvasModel.toPostMap() did not have expected value for field2", FIELD2_VALUE, postMap.get(expectedKey));
+    }
+
+    /* Make sure canvasFields with arrays = true and an override key are of form override[field] */
+    @Test
+    public void postKeysAsArraysWithOverrideKeySetCorrectly() throws Exception {
+        final String expectedKey = CLASS_POST_KEY_OVERRIDE + "[" + FIELD3_POST_KEY + "]";
+        final TestCanvasModel canvasModel = new TestCanvasModel();
+        canvasModel.setField3(FIELD3_VALUE);
+
+        final Map<String, Object> postMap = canvasModel.toPostMap();
+
+        Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field3", postMap.containsKey(expectedKey));
+        Assert.assertEquals("Field3Value from canvasModel.toPostMap() did not have expected value for field3", FIELD3_VALUE, postMap.get(expectedKey));
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/model/TestCanvasModel.java
+++ b/src/test/java/edu/ksu/canvas/model/TestCanvasModel.java
@@ -12,6 +12,7 @@ import edu.ksu.canvas.annotation.CanvasObject;
 public class TestCanvasModel extends BaseCanvasModel {
     private String field1;
     private String field2;
+    private String field3;
 
     @CanvasField(postKey = BaseCanvasModelUTest.FIELD1_POST_KEY)
     public String getField1() {
@@ -29,5 +30,14 @@ public class TestCanvasModel extends BaseCanvasModel {
 
     public void setField2(String field2) {
         this.field2 = field2;
+    }
+
+    @CanvasField(overrideObjectKey = BaseCanvasModelUTest.CLASS_POST_KEY_OVERRIDE, postKey = BaseCanvasModelUTest.FIELD3_POST_KEY)
+    public String getField3() {
+        return field3;
+    }
+
+    public void setField3(final String field3) {
+        this.field3 = field3;
     }
 }

--- a/src/test/java/edu/ksu/canvas/model/TestCanvasModel.java
+++ b/src/test/java/edu/ksu/canvas/model/TestCanvasModel.java
@@ -4,6 +4,8 @@ import edu.ksu.canvas.BaseCanvasModelUTest;
 import edu.ksu.canvas.annotation.CanvasField;
 import edu.ksu.canvas.annotation.CanvasObject;
 
+import java.util.List;
+
 /*
  * Class was created to help test BaseCanvasModel. The class needs to be public in order for the
  * reflection in BaseCanvasModel to work
@@ -13,6 +15,8 @@ public class TestCanvasModel extends BaseCanvasModel {
     private String field1;
     private String field2;
     private String field3;
+    private Integer field4;
+    private List<Integer> field5;
 
     @CanvasField(postKey = BaseCanvasModelUTest.FIELD1_POST_KEY)
     public String getField1() {
@@ -39,5 +43,23 @@ public class TestCanvasModel extends BaseCanvasModel {
 
     public void setField3(final String field3) {
         this.field3 = field3;
+    }
+
+    @CanvasField(postKey = BaseCanvasModelUTest.FIELD4_POST_KEY)
+    public Integer getField4() {
+        return field4;
+    }
+
+    public void setField4(final Integer field4) {
+        this.field4 = field4;
+    }
+
+    @CanvasField(postKey = BaseCanvasModelUTest.FIELD5_POST_KEY)
+    public List<Integer> getField5() {
+        return field5;
+    }
+
+    public void setField5(final List<Integer> field5) {
+        this.field5 = field5;
     }
 }

--- a/src/test/java/edu/ksu/canvas/net/FakeRestClient.java
+++ b/src/test/java/edu/ksu/canvas/net/FakeRestClient.java
@@ -10,6 +10,7 @@ import javax.validation.constraints.NotNull;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class FakeRestClient implements RestClient {
@@ -39,21 +40,21 @@ public class FakeRestClient implements RestClient {
     }
 
     @Override
-    public Response sendApiPost(OauthToken token, String url, Map<String, String> postParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
+    public Response sendApiPost(OauthToken token, String url, Map<String, List<String>> postParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         LOG.debug("Sending fake POST to " + url);
         checkForTimeout(connectTimeout, readTimeout);
         return response(url);
     }
 
     @Override
-    public Response sendApiDelete(@NotNull OauthToken token, @NotNull String url, Map<String, String> deleteParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
+    public Response sendApiDelete(@NotNull OauthToken token, @NotNull String url, Map<String, List<String>> deleteParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         LOG.debug("Sending fake DEL to " + url);
         checkForTimeout(connectTimeout, readTimeout);
         return response(url);
     }
 
     @Override
-    public Response sendApiPut(@NotNull OauthToken token, @NotNull String url, Map<String, Object> putParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
+    public Response sendApiPut(@NotNull OauthToken token, @NotNull String url, Map<String, List<String>> putParameters, int connectTimeout, int readTimeout) throws InvalidOauthTokenException, IOException {
         LOG.debug("Sending fake PUT to " + url);
         checkForTimeout(connectTimeout, readTimeout);
         return response(url);

--- a/src/test/java/edu/ksu/canvas/net/RefreshingRestClientUTest.java
+++ b/src/test/java/edu/ksu/canvas/net/RefreshingRestClientUTest.java
@@ -10,6 +10,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
@@ -32,8 +33,7 @@ public class RefreshingRestClientUTest {
 
     private final String arbitraryString = "arbitraryString";
     private final int arbitraryInt = 1;
-    private final Map<String, String> arbitraryMap = Collections.emptyMap();
-    private final Map<String, Object> arbitraryObjectMap = Collections.emptyMap();
+    private final Map<String, List<String>> arbitraryMap = Collections.emptyMap();
     private final Response response = new Response();
 
     @Before
@@ -71,7 +71,7 @@ public class RefreshingRestClientUTest {
                 .thenThrow(InvalidOauthTokenException.class)
                 .thenReturn(response);
 
-        Response returnedResponse = refreshRestClientUTest.sendApiPut(mockToken, arbitraryString, arbitraryObjectMap, arbitraryInt, arbitraryInt);
+        Response returnedResponse = refreshRestClientUTest.sendApiPut(mockToken, arbitraryString, arbitraryMap, arbitraryInt, arbitraryInt);
 
         verify(mockToken, times(1)).refresh();
         assertEquals("Expected response to be response returned from mockRestClient", response, returnedResponse);


### PR DESCRIPTION
Hello,

This PR is more for discussion and a request for your input than a serious contribution, though feel free to cherry-pick anything you find useful

 I'm currently in the process of exploring the Canvas REST API and will need to build functionality to create/update users, courses, and enrolments. It looks like you've got a great foundation for that here.

However, the CanvasField and toPostMap mechanism for serialization doesn't work too well when the API expects the same things to have different names, depending on the endpoint. For example, when creating a user, the email address goes into communication_channel[address]; when editing, user[email]; and when retrieving a user, email.

My first question would be whether you'd be open to external contributors to this project. If so, my main question would be, have you encountered this problem yourselves, and do you have any thoughts on what to do about it?

Additionally, it looks to me as though the pattern of passing request option objects will have to be extended to non-GET type methods, in order to support options such as whether to notify a user that an account has been created, as there are many such options and they don't belong in the model. Does this seem like the correct approach to you?

Thanks

William