### PR TITLE
Fixes to make Scantron fully functional (Lk1028)

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/QuizImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizImpl.java
@@ -45,7 +45,7 @@ public class QuizImpl extends BaseImpl<Quiz, QuizReader, QuizWriter> implements 
     public Optional<Quiz> updateQuiz(Quiz quiz, String courseId) throws MessageUndeliverableException, IOException {
         LOG.debug("Updating quiz " + quiz.getId() + " in course " + courseId);
         String url = buildCanvasUrl("courses/" + courseId + "/quizzes/" + quiz.getId(), Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url,quiz.toJsonObject());
+        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url,quiz.toJsonObject());
         return responseParser.parseToObject(Quiz.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/QuizQuestionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizQuestionImpl.java
@@ -14,6 +14,7 @@ import org.apache.log4j.Logger;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -31,6 +32,19 @@ public class QuizQuestionImpl extends BaseImpl<QuizQuestion, QuizQuestionReader,
         List<Response> responses = canvasMessenger.getFromCanvas(oauthToken, url);
         return parseQuizQuestionList(responses);
 
+    }
+
+    @Override
+    public boolean deleteQuizQuestion(String courseId, Integer quizId, Integer questionId) throws IOException {
+        LOG.debug("Deleting quiz question in course " + courseId + ", quiz " + quizId + ", question " + questionId);
+        String url = buildCanvasUrl("courses/" + courseId + "/quizzes/" + quizId + "/" + questionId, Collections.emptyMap());
+        Response response = canvasMessenger.deleteFromCanvas(oauthToken, url, Collections.emptyMap());
+        int responseCode = response.getResponseCode();
+        if (responseCode == 204) {
+            return true;
+        }
+        LOG.error("Canvas returned code " + responseCode + " (success = 204) when deleting question " + questionId);
+        return false;
     }
 
     private List <QuizQuestion> parseQuizQuestionList(final List<Response> responses) {

--- a/src/main/java/edu/ksu/canvas/impl/QuizQuestionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizQuestionImpl.java
@@ -13,10 +13,8 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class QuizQuestionImpl extends BaseImpl<QuizQuestion, QuizQuestionReader, QuizQuestionWriter> implements QuizQuestionReader, QuizQuestionWriter {
     private static final Logger LOG = Logger.getLogger(QuizQuestionImpl.class);
@@ -27,11 +25,10 @@ public class QuizQuestionImpl extends BaseImpl<QuizQuestion, QuizQuestionReader,
 
     @Override
     public List<QuizQuestion> getQuizQuestions(GetQuizQuestionsOptions options) throws IOException {
+        LOG.debug("Fetching quiz questions for quiz " + options.getQuizId() + " in course " + options.getCourseId());
         String url = buildCanvasUrl("courses/" + options.getCourseId() + "/quizzes/" + options.getQuizId() + "/questions",
                 options.getOptionsMap());
-        List<Response> responses = canvasMessenger.getFromCanvas(oauthToken, url);
-        return parseQuizQuestionList(responses);
-
+        return getListFromCanvas(url);
     }
 
     @Override
@@ -45,18 +42,6 @@ public class QuizQuestionImpl extends BaseImpl<QuizQuestion, QuizQuestionReader,
         }
         LOG.error("Canvas returned code " + responseCode + " (success = 204) when deleting question " + questionId);
         return false;
-    }
-
-    private List <QuizQuestion> parseQuizQuestionList(final List<Response> responses) {
-        return responses.stream().
-                map(this::parseQuizQuestionList).
-                flatMap(Collection::stream).
-                collect(Collectors.toList());
-    }
-
-    private List<QuizQuestion> parseQuizQuestionList(final Response response) {
-        Type listType = new TypeToken<List<QuizQuestion>>(){}.getType();
-        return GsonResponseParser.getDefaultGsonParser().fromJson(response.getContent(), listType);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/interfaces/QuizQuestionWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/QuizQuestionWriter.java
@@ -1,6 +1,18 @@
 package edu.ksu.canvas.interfaces;
 
+import java.io.IOException;
+
 import edu.ksu.canvas.model.assignment.QuizQuestion;
 
 public interface QuizQuestionWriter extends CanvasWriter<QuizQuestion, QuizQuestionWriter> {
+
+    /**
+     * Delete a quiz question
+     * @param courseId Course ID containing the quiz to modify
+     * @param quizId Quiz ID with question to delete
+     * @param questionId Question ID of question to delete
+     * @return true if deletion was successful (API returned HTTP 204), false otherwise
+     * @throws IOException if there is an error communicating with Canvas
+     */
+    public boolean deleteQuizQuestion(String courseId, Integer quizId, Integer questionId) throws IOException;
 }

--- a/src/main/java/edu/ksu/canvas/model/assignment/QuizQuestion.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/QuizQuestion.java
@@ -127,7 +127,7 @@ public class QuizQuestion extends BaseCanvasModel {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if(!(o instanceof QuizQuestion)) return false;
 
         QuizQuestion that = (QuizQuestion) o;
 


### PR DESCRIPTION
These include:
- Implementing quiz question deletion
- Fixing quiz editing call to use `PUT` instead of `POST`
- Replacing old parsing methods with common ones in the base implementation class
- Modifying how equals behaves with inheritance