### PR TITLE
Add a method that allows more fine-grained control over creating enrollments.

### DIFF
--- a/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
+++ b/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
@@ -157,6 +157,7 @@ public class CanvasApiFactory {
         writerMap.put(QuizSubmissionWriter.class, QuizSubmissionImpl.class);
         writerMap.put(UserWriter.class, UserImpl.class);
         writerMap.put(PageWriter.class, PageImpl.class);
+        writerMap.put(SectionWriter.class, SectionsImpl.class);
         writerMap.put(SubmissionWriter.class, SubmissionImpl.class);
     }
 }

--- a/src/main/java/edu/ksu/canvas/impl/SectionsImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/SectionsImpl.java
@@ -18,6 +18,7 @@ import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -59,23 +60,21 @@ public class SectionsImpl extends BaseImpl<Section, SectionReader, SectionWriter
     }
 
     @Override
-    public Optional<Section> createSection(String courseId, Section section) throws IOException {
+    public Optional<Section> createSection(String courseId, Section section, boolean enableSisReactivation)
+            throws IOException {
         LOG.debug("creating section for course " + courseId);
+        Map<String, String> params = new HashMap<>();
+        params.put("enable_sis_reactivation", Boolean.toString(enableSisReactivation));
         String url = buildCanvasUrl(String.format("/courses/%s/sections", courseId), Collections.emptyMap());
         Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, section.toJsonObject());
         return responseParser.parseToObject(Section.class, response);
     }
 
     @Override
-    public Boolean deleteSection(String sectionId) throws IOException {
+    public Optional<Section> deleteSection(String sectionId) throws IOException {
         LOG.debug("deleting section " + sectionId);
         String url = buildCanvasUrl("/sections/" + sectionId, Collections.emptyMap());
         Response response = canvasMessenger.deleteFromCanvas(oauthToken, url, Collections.emptyMap());
-        if (response.getErrorHappened() || response.getResponseCode() != 200) {
-            LOG.debug(String.format("Failed to delete section %s, error message: %s", sectionId, response.toString()));
-            return false;
-        }
-        Optional<Delete> responseParsed = responseParser.parseToObject(Delete.class, response);
-        return responseParsed.map(r -> r.getDelete()).orElse(false);
+        return responseParser.parseToObject(Section.class, response);
     }
 }

--- a/src/main/java/edu/ksu/canvas/impl/SectionsImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/SectionsImpl.java
@@ -7,6 +7,7 @@ import edu.ksu.canvas.enums.SectionIncludes;
 import edu.ksu.canvas.interfaces.SectionReader;
 import edu.ksu.canvas.interfaces.SectionWriter;
 import edu.ksu.canvas.model.Section;
+import edu.ksu.canvas.model.status.Delete;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
@@ -14,12 +15,14 @@ import org.apache.log4j.Logger;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-public class SectionsImpl extends BaseImpl<Section, SectionReader, SectionWriter> implements SectionReader {
+public class SectionsImpl extends BaseImpl<Section, SectionReader, SectionWriter> implements SectionReader,
+        SectionWriter {
 
     private static final Logger LOG = Logger.getLogger(SectionReader.class);
 
@@ -55,4 +58,24 @@ public class SectionsImpl extends BaseImpl<Section, SectionReader, SectionWriter
         return Section.class;
     }
 
+    @Override
+    public Optional<Section> createSection(String courseId, Section section) throws IOException {
+        LOG.debug("creating section for course " + courseId);
+        String url = buildCanvasUrl(String.format("/courses/%s/sections", courseId), Collections.emptyMap());
+        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, section.toJsonObject());
+        return responseParser.parseToObject(Section.class, response);
+    }
+
+    @Override
+    public Boolean deleteSection(String sectionId) throws IOException {
+        LOG.debug("deleting section " + sectionId);
+        String url = buildCanvasUrl("/sections/" + sectionId, Collections.emptyMap());
+        Response response = canvasMessenger.deleteFromCanvas(oauthToken, url, Collections.emptyMap());
+        if (response.getErrorHappened() || response.getResponseCode() != 200) {
+            LOG.debug(String.format("Failed to delete section %s, error message: %s", sectionId, response.toString()));
+            return false;
+        }
+        Optional<Delete> responseParsed = responseParser.parseToObject(Delete.class, response);
+        return responseParsed.map(r -> r.getDelete()).orElse(false);
+    }
 }

--- a/src/main/java/edu/ksu/canvas/interfaces/SectionWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/SectionWriter.java
@@ -16,17 +16,20 @@ public interface SectionWriter extends CanvasWriter<Section, SectionWriter> {
      * @param courseId identifies the parent course we are adding this section to
      * @param section a section object containing the information needed to create
      *         the section in Canvas
+     * @param enableSisReactivation when true, will first try to re-activate a
+     *         deleted section with matching sis_section_id if possible
      * @return the newly created section
      * @throws IOException
      */
-    Optional<Section> createSection(String courseId, Section section) throws IOException;
+    Optional<Section> createSection(String courseId, Section section, boolean enableSisReactivation) throws IOException;
 
     /**
      * Delete an existing section in Canvas.
      *
      * @param sectionId identifies the section to delete
      * @return true if the delete was successful
+     * @return the section object that was deleted
      * @throws IOException
      */
-    Boolean deleteSection(String sectionId) throws IOException;
+    Optional<Section> deleteSection(String sectionId) throws IOException;
 }

--- a/src/main/java/edu/ksu/canvas/interfaces/SectionWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/SectionWriter.java
@@ -1,7 +1,32 @@
 package edu.ksu.canvas.interfaces;
 
+import java.io.IOException;
+import java.util.Optional;
+
+import edu.ksu.canvas.model.Section;
+
 /**
  * Created by japshvincent on 4/28/16.
  */
-public interface SectionWriter extends CanvasWriter {
+public interface SectionWriter extends CanvasWriter<Section, SectionWriter> {
+
+    /**
+     * Create a new section in Canvas.
+     *
+     * @param courseId identifies the parent course we are adding this section to
+     * @param section a section object containing the information needed to create
+     *         the section in Canvas
+     * @return the newly created section
+     * @throws IOException
+     */
+    Optional<Section> createSection(String courseId, Section section) throws IOException;
+
+    /**
+     * Delete an existing section in Canvas.
+     *
+     * @param sectionId identifies the section to delete
+     * @return true if the delete was successful
+     * @throws IOException
+     */
+    Boolean deleteSection(String sectionId) throws IOException;
 }


### PR DESCRIPTION
Along with an Options object for specifying all of the parameters available to the call, discussed at https://canvas.instructure.com/doc/api/enrollments.html#method.enrollments_api.create

Our use case for this is we want to automatically enroll students in our Canvas courses without the students having to accept an invitation (which is the default).
