### PR TITLE
Add a new method that allows for creating enrollments with more options.

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
@@ -10,6 +10,7 @@ import edu.ksu.canvas.model.Enrollment;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
+import edu.ksu.canvas.requestOptions.EnrollUserOptions;
 import edu.ksu.canvas.requestOptions.GetEnrollmentOptions;
 
 import org.apache.log4j.Logger;
@@ -48,11 +49,17 @@ public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, Enrol
 
     @Override
     public Optional<Enrollment> enrollUser(String courseId, String userId) throws InvalidOauthTokenException, IOException {
-        Map<String, List<String>> courseMap = new HashMap<>();
-        courseMap.put("enrollment[user_id]", Collections.singletonList(String.valueOf(userId)));
+        EnrollUserOptions options = new EnrollUserOptions();
+        options.userId(userId);
+        return enrollUser(courseId, options);
+    }
+
+    @Override
+    public Optional<Enrollment> enrollUser(String courseId, EnrollUserOptions options)
+            throws InvalidOauthTokenException, IOException {
         String createdUrl = buildCanvasUrl("courses/" + courseId + "/enrollments", Collections.emptyMap());
         LOG.debug("create URl for course enrollments: "+ createdUrl);
-        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, courseMap);
+        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, options.getOptionsMap());
         if (response.getErrorHappened() ||  response.getResponseCode() != 200) {
             LOG.debug("Failed to enroll in course, error message: " + response.toString());
             return Optional.empty();

--- a/src/main/java/edu/ksu/canvas/interfaces/EnrollmentWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/EnrollmentWriter.java
@@ -2,6 +2,7 @@ package edu.ksu.canvas.interfaces;
 
 import edu.ksu.canvas.exception.InvalidOauthTokenException;
 import edu.ksu.canvas.model.Enrollment;
+import edu.ksu.canvas.requestOptions.EnrollUserOptions;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -11,7 +12,29 @@ import java.util.Optional;
  */
 public interface EnrollmentWriter extends CanvasWriter<Enrollment, EnrollmentWriter> {
 
-     Optional<Enrollment> enrollUser(String courseId, String enrollmentId) throws InvalidOauthTokenException, IOException;
+     /**
+      * Enrolls a user in a course using the defaults defined by Canvas.
+      *
+      * @param courseId Canvas course identifier
+      * @param userId Canvas user identifier
+      * @return populated Enrollment object that was created
+      * @throws InvalidOauthTokenException
+      * @throws IOException
+      */
+     Optional<Enrollment> enrollUser(String courseId, String userId) throws InvalidOauthTokenException, IOException;
+
+     /**
+      * Enrolls a user in a course, allowing all the options exposed by Canvas
+      * to be changed.
+      *
+      * @param courseId Canvas course identifier
+      * @param options the object holding options for the API call
+      * @return populated Enrollment object that was created
+      * @throws InvalidOauthTokenException
+      * @throws IOException
+      */
+     Optional<Enrollment> enrollUser(String courseId, EnrollUserOptions options) throws InvalidOauthTokenException,
+               IOException;
 
      Optional<Enrollment> dropUser(String courseId, String enrollmentId) throws InvalidOauthTokenException, IOException;
 }

--- a/src/main/java/edu/ksu/canvas/requestOptions/EnrollUserOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/EnrollUserOptions.java
@@ -1,0 +1,89 @@
+package edu.ksu.canvas.requestOptions;
+
+/**
+ * Options available when creating an enrollment.  See
+ * https://canvas.instructure.com/doc/api/enrollments.html#method.enrollments_api.create
+ * for a discussion of these.
+ */
+public class EnrollUserOptions extends BaseOptions {
+
+    public enum EnrollmentType {
+        STUDENT("StudentEnrollment"),
+        TEACHER("TeacherEnrollment"),
+        TA("TaEnrollment"),
+        DESIGNER("DesignerEnrollment"),
+        OBSERVER("ObserverEnrollment");
+
+        private String canvasValue;
+
+        EnrollmentType(String canvasValue) {
+            this.canvasValue = canvasValue;
+        }
+
+        @Override
+        public String toString() {
+            return canvasValue;
+        }
+    }
+
+    public enum EnrollmentState {
+        ACTIVE,
+        INVITED,
+        INACTIVE;
+
+        @Override
+        public String toString() {
+            return name().toLowerCase();
+        }
+    }
+
+    public EnrollUserOptions userId(String userId) {
+        addSingleItem("enrollment[user_id]", userId);
+        return this;
+    }
+
+    public EnrollUserOptions type(EnrollmentType enrollmentType) {
+        addSingleItem("enrollment[type]", enrollmentType.toString());
+        return this;
+    }
+
+    public EnrollUserOptions role(long role) {
+        addSingleItem("enrollment[role_id]", Long.toString(role));
+        return this;
+    }
+
+    public EnrollUserOptions state(EnrollmentState enrollmentState) {
+        addSingleItem("enrollment[enrollment_state]", enrollmentState.toString());
+        return this;
+    }
+
+    public EnrollUserOptions courseSectionId(long courseSectionId) {
+        addSingleItem("enrollment[course_section_id]", Long.toString(courseSectionId));
+        return this;
+    }
+
+    public EnrollUserOptions limitPrivilegesToCourseSection(boolean limit) {
+        addSingleItem("enrollment[limit_privileges_to_course_section]", Boolean.toString(limit));
+        return this;
+    }
+
+    public EnrollUserOptions notify(boolean notify) {
+        addSingleItem("enrollment[notify]", Boolean.toString(notify));
+        return this;
+    }
+
+    public EnrollUserOptions selfEnrollmentCode(String selfEnrollmentCode) {
+        addSingleItem("enrollment[self_enrollment_code]", selfEnrollmentCode);
+        return this;
+    }
+
+    public EnrollUserOptions selfEnrolled(boolean selfEnrolled) {
+        addSingleItem("enrollment[self_enrolled]", Boolean.toString(selfEnrolled));
+        return this;
+    }
+
+    public EnrollUserOptions associatedUserId(long associatedUserId) {
+        addSingleItem("enrollment[associated_user_id]", Long.toString(associatedUserId));
+        return this;
+    }
+}


### PR DESCRIPTION
Along with an Options object for specifying all of the parameters available to the call, discussed at https://canvas.instructure.com/doc/api/enrollments.html#method.enrollments_api.create

Our use case for this is we want to automatically enroll students in our Canvas courses without the students having to accept an invitation (which is the default).