### PR TITLE
Added a new dropUser() method to EnrollmentWriter and a new UnEnrollO…

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
@@ -12,6 +12,7 @@ import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.GetEnrollmentOptions;
 
+import edu.ksu.canvas.requestOptions.UnEnrollOptions;
 import org.apache.log4j.Logger;
 
 import java.io.IOException;
@@ -64,8 +65,13 @@ public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, Enrol
 
     @Override
     public Optional<Enrollment> dropUser(String courseId, String enrollmentId) throws InvalidOauthTokenException, IOException {
+        return dropUser(courseId, enrollmentId, UnEnrollOptions.DELETE.toString());
+    }
+
+    @Override
+    public Optional<Enrollment> dropUser(String courseId, String enrollmentId, String unEnrollOption) throws InvalidOauthTokenException, IOException {
         Map<String, List<String>> postParams = new HashMap<>();
-        postParams.put("task", Collections.singletonList("delete"));
+        postParams.put("task", Collections.singletonList(unEnrollOption));
         String createdUrl = buildCanvasUrl("courses/" + courseId + "/enrollments/" + enrollmentId, Collections.emptyMap());
         LOG.debug("create URl for course enrollments: "+ createdUrl);
         Response response = canvasMessenger.deleteFromCanvas(oauthToken, createdUrl, postParams);

--- a/src/main/java/edu/ksu/canvas/interfaces/EnrollmentWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/EnrollmentWriter.java
@@ -13,5 +13,28 @@ public interface EnrollmentWriter extends CanvasWriter<Enrollment, EnrollmentWri
 
      Optional<Enrollment> enrollUser(Enrollment enrollment) throws InvalidOauthTokenException, IOException;
 
+     /**
+      *
+      * Drop a user enrolled in a course passing the UnEnrollOptions string (i.e. canvas task param).
+      *
+      * @param courseId - Canvas course identifier
+      * @param enrollmentId - Canvas enrollment identifier
+      * @param unEnrollOption - UnEnrollOption enum toString value of delete, conclude, inactivate or deactivate
+      * @return Populated Enrollment Dropped when successful
+      * @throws InvalidOauthTokenException
+      * @throws IOException
+      */
+     Optional<Enrollment> dropUser(String courseId, String enrollmentId, String unEnrollOption) throws InvalidOauthTokenException, IOException;
+
+     /**
+      *
+      *  Drop a user enrolled in a course using the Unenrollment option of DELETE.
+      *
+      * @param courseId - Canvas course identifier
+      * @param enrollmentId enrollmentId - Canvas enrollment identifier
+      * @return Populated Enrollment Dropped when successful
+      * @throws InvalidOauthTokenException
+      * @throws IOException
+      */
      Optional<Enrollment> dropUser(String courseId, String enrollmentId) throws InvalidOauthTokenException, IOException;
 }

--- a/src/main/java/edu/ksu/canvas/requestOptions/UnEnrollOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/UnEnrollOptions.java
@@ -1,0 +1,24 @@
+package edu.ksu.canvas.requestOptions;
+
+
+/**
+ *
+ *  UnEnrollOptions denote the canvas Enrollment dropUser's task request parameter supported values. See
+ *  https://canvas.instructure.com/doc/api/enrollments.html#method.enrollments_api.destroy
+ *  for a discussion of these.
+ */
+public enum UnEnrollOptions {
+    DELETE("delete"),
+    CONCLUDE("conclude"),
+    INACTIVATE("inactivate"),
+    DEACTIVATE("deactivate");
+
+    private String canvasValue;
+
+    UnEnrollOptions(String canvasValue) {this.canvasValue = canvasValue;}
+
+    @Override
+    public String toString() {
+        return canvasValue;
+    }
+}


### PR DESCRIPTION
Hello, I'm a developer at CU Boulder working on our Canvas project. We'd like to unEnroll students with the task param supported in cavas. See https://canvas.instructure.com/doc/api/enrollments.html#method.enrollments_api.destroy.
This pull request adds a new dropUser() method and updates the existing dropUser() method to leverage UnEnrollOptions requestOption.