### PR TITLE
Logins & Enrollment.userId

### DIFF
--- a/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
+++ b/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
@@ -147,6 +147,7 @@ public class CanvasApiFactory {
         readerMap.put(AssignmentGroupReader.class, AssignmentGroupImpl.class);
         readerMap.put(RoleReader.class, RoleImpl.class);
         readerMap.put(ExternalToolReader.class, ExternalToolImpl.class);
+        readerMap.put(LoginReader.class, LoginImpl.class);
 
         writerMap.put(AssignmentOverrideWriter.class, AssignmentOverrideImpl.class);
         writerMap.put(AssignmentWriter.class, AssignmentImpl.class);
@@ -165,5 +166,6 @@ public class CanvasApiFactory {
         writerMap.put(AssignmentGroupWriter.class, AssignmentGroupImpl.class);
         writerMap.put(RoleWriter.class, RoleImpl.class);
         writerMap.put(ExternalToolWriter.class, ExternalToolImpl.class);
+        writerMap.put(LoginWriter.class, LoginImpl.class);
     }
 }

--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
@@ -65,7 +65,7 @@ public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, Enrol
         if (enrollment.getCourseId() == null || enrollment.getCourseId() == 0) {
             throw new IllegalArgumentException("Required CourseId in enrollment was not found.");
         }
-        LOG.debug(String.format("Enrolling user %d in course %d", enrollment.getUserId(), enrollment.getCourseId()));
+        LOG.debug(String.format("Enrolling user %s in course %d", enrollment.getUserId(), enrollment.getCourseId()));
         return enrollUser(enrollment, false);
     }
 
@@ -74,7 +74,7 @@ public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, Enrol
         if (StringUtils.isBlank(enrollment.getCourseSectionId())) {
             throw new IllegalArgumentException("Required CourseSectionId in enrollment was not found.");
         }
-        LOG.debug(String.format("Enrolling user %d in section %d", enrollment.getUserId(), enrollment.getCourseSectionId()));
+        LOG.debug(String.format("Enrolling user %s in section %s", enrollment.getUserId(), enrollment.getCourseSectionId()));
         return enrollUser(enrollment,true);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/LoginImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/LoginImpl.java
@@ -1,0 +1,44 @@
+package edu.ksu.canvas.impl;
+
+import static java.util.Collections.emptyMap;
+
+import com.google.gson.reflect.TypeToken;
+
+import edu.ksu.canvas.interfaces.*;
+import edu.ksu.canvas.model.Login;
+import edu.ksu.canvas.net.RestClient;
+import edu.ksu.canvas.oauth.OauthToken;
+
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.List;
+
+public class LoginImpl extends BaseImpl<Login, LoginReader, LoginWriter> implements LoginReader {
+	private static final Logger LOG = Logger.getLogger(LoginImpl.class);
+
+	public LoginImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+			int connectTimeout, int readTimeout, Integer paginationPageSize) {
+		super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+	}
+
+	@Override
+	public List<Login> getLoginForUser(String userId) throws IOException {
+		LOG.debug("Retrieving logins for user id " + userId);
+		String url = buildCanvasUrl("users/" + userId + "/logins", emptyMap());
+
+		return getListFromCanvas(url);
+	}
+
+	@Override
+	protected Type listType() {
+		return new TypeToken<List<Login>>() {
+		}.getType();
+	}
+
+	@Override
+	protected Class<Login> objectType() {
+		return Login.class;
+	}
+}

--- a/src/main/java/edu/ksu/canvas/interfaces/LoginReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/LoginReader.java
@@ -1,0 +1,10 @@
+package edu.ksu.canvas.interfaces;
+
+import edu.ksu.canvas.model.Login;
+
+import java.io.IOException;
+import java.util.List;
+
+public interface LoginReader extends CanvasReader<Login, LoginReader> {
+	public List<Login> getLoginForUser(String userId) throws IOException;
+}

--- a/src/main/java/edu/ksu/canvas/interfaces/LoginReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/LoginReader.java
@@ -6,5 +6,11 @@ import java.io.IOException;
 import java.util.List;
 
 public interface LoginReader extends CanvasReader<Login, LoginReader> {
+    /**
+     * Retrieve a user's logins.
+     * @param userId the id of the user to retrieve logins for
+     * @return List of the user's logins
+     * @throws IOException When there is an error communicating with Canvas
+     */
 	public List<Login> getLoginForUser(String userId) throws IOException;
 }

--- a/src/main/java/edu/ksu/canvas/interfaces/LoginWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/LoginWriter.java
@@ -1,0 +1,7 @@
+package edu.ksu.canvas.interfaces;
+
+import edu.ksu.canvas.model.Login;
+
+public interface LoginWriter extends CanvasWriter<Login, LoginWriter> {
+
+}

--- a/src/main/java/edu/ksu/canvas/model/Enrollment.java
+++ b/src/main/java/edu/ksu/canvas/model/Enrollment.java
@@ -12,7 +12,7 @@ import java.util.Date;
  */
 @CanvasObject(postKey = "enrollment")
 public class Enrollment extends BaseCanvasModel implements Serializable {
-    public static final long serialVersionUID = 1L;
+    public static final long serialVersionUID = 2L;
 
     private long id;
     private Integer courseId;

--- a/src/main/java/edu/ksu/canvas/model/Enrollment.java
+++ b/src/main/java/edu/ksu/canvas/model/Enrollment.java
@@ -26,7 +26,7 @@ public class Enrollment extends BaseCanvasModel implements Serializable {
     private String sisImportId;
     private Integer rootAccountId;
     private String type;
-    private Integer userId;
+    private String userId;
     private Integer associatedUserId;
     private String role;
     private Date updatedAt;
@@ -148,11 +148,11 @@ public class Enrollment extends BaseCanvasModel implements Serializable {
     }
 
     @CanvasField(postKey = "user_id")
-    public Integer getUserId() {
+    public String getUserId() {
         return userId;
     }
 
-    public void setUserId(Integer userId) {
+    public void setUserId(String userId) {
         this.userId = userId;
     }
 

--- a/src/main/java/edu/ksu/canvas/model/Login.java
+++ b/src/main/java/edu/ksu/canvas/model/Login.java
@@ -1,0 +1,92 @@
+package edu.ksu.canvas.model;
+
+import edu.ksu.canvas.annotation.*;
+
+import java.io.Serializable;
+
+/**
+ * Class to represent Canvas user logins. See the
+ * <a href="https://canvas.instructure.com/doc/api/logins.html">Logins API</a>
+ * documentation.
+ */
+@CanvasObject(postKey = "login")
+@SuppressWarnings("serial")
+public class Login extends BaseCanvasModel implements Serializable {
+	private int id;
+	private int userId;
+	private int accountId;
+	private String uniqueId;
+	private String sisUserId;
+	private String integrationId;
+	private int integrationProviderId;
+	private String integrationProviderType;
+
+	public int getId() {
+		return id;
+	}
+
+	public void setId(int id) {
+		this.id = id;
+	}
+
+	@CanvasField(overrideObjectKey = "user", postKey = "user_id")
+	public int getUserId() {
+		return userId;
+	}
+
+	public void setUserId(int userId) {
+		this.userId = userId;
+	}
+
+	public int getAccountId() {
+		return accountId;
+	}
+
+	public void setAccountId(int accountId) {
+		this.accountId = accountId;
+	}
+
+	@CanvasField(postKey = "unique_id")
+	public String getUniqueId() {
+		return uniqueId;
+	}
+
+	public void setUniqueId(String uniqueId) {
+		this.uniqueId = uniqueId;
+	}
+
+	@CanvasField(postKey = "sis_user_id")
+	public String getSisUserId() {
+		return sisUserId;
+	}
+
+	public void setSisUserId(String sisUserId) {
+		this.sisUserId = sisUserId;
+	}
+
+	@CanvasField(postKey = "integration_id")
+	public String getIntegrationId() {
+		return integrationId;
+	}
+
+	public void setIntegrationId(String integrationId) {
+		this.integrationId = integrationId;
+	}
+
+	@CanvasField(postKey = "integration_provider_id")
+	public int getIntegrationProviderId() {
+		return integrationProviderId;
+	}
+
+	public void setIntegrationProviderId(int integrationProviderId) {
+		this.integrationProviderId = integrationProviderId;
+	}
+
+	public String getIntegrationProviderType() {
+		return integrationProviderType;
+	}
+
+	public void setIntegrationProviderType(String integrationProviderType) {
+		this.integrationProviderType = integrationProviderType;
+	}
+}

--- a/src/main/java/edu/ksu/canvas/model/Login.java
+++ b/src/main/java/edu/ksu/canvas/model/Login.java
@@ -12,37 +12,37 @@ import java.io.Serializable;
 @CanvasObject(postKey = "login")
 @SuppressWarnings("serial")
 public class Login extends BaseCanvasModel implements Serializable {
-	private int id;
-	private int userId;
-	private int accountId;
+	private String id;
+	private String userId;
+	private String accountId;
 	private String uniqueId;
 	private String sisUserId;
 	private String integrationId;
-	private int integrationProviderId;
-	private String integrationProviderType;
+	private String authenticationProviderId;
+	private String authenticationProviderType;
 
-	public int getId() {
+	public String getId() {
 		return id;
 	}
 
-	public void setId(int id) {
+	public void setId(String id) {
 		this.id = id;
 	}
 
 	@CanvasField(overrideObjectKey = "user", postKey = "user_id")
-	public int getUserId() {
+	public String getUserId() {
 		return userId;
 	}
 
-	public void setUserId(int userId) {
+	public void setUserId(String userId) {
 		this.userId = userId;
 	}
 
-	public int getAccountId() {
+	public String getAccountId() {
 		return accountId;
 	}
 
-	public void setAccountId(int accountId) {
+	public void setAccountId(String accountId) {
 		this.accountId = accountId;
 	}
 
@@ -73,20 +73,20 @@ public class Login extends BaseCanvasModel implements Serializable {
 		this.integrationId = integrationId;
 	}
 
-	@CanvasField(postKey = "integration_provider_id")
-	public int getIntegrationProviderId() {
-		return integrationProviderId;
+	@CanvasField(postKey = "authentication_provider_id")
+	public String getAuthenticationProviderId() {
+		return authenticationProviderId;
 	}
 
-	public void setIntegrationProviderId(int integrationProviderId) {
-		this.integrationProviderId = integrationProviderId;
+	public void setAuthenticationProviderId(String authenticationProviderId) {
+		this.authenticationProviderId = authenticationProviderId;
 	}
 
-	public String getIntegrationProviderType() {
-		return integrationProviderType;
+	public String getAuthenticationProviderType() {
+		return authenticationProviderType;
 	}
 
-	public void setIntegrationProviderType(String integrationProviderType) {
-		this.integrationProviderType = integrationProviderType;
+	public void setAuthenticationProviderType(String authenticationProviderType) {
+		this.authenticationProviderType = authenticationProviderType;
 	}
 }

--- a/src/test/java/edu/ksu/canvas/EnrollmentUTest.java
+++ b/src/test/java/edu/ksu/canvas/EnrollmentUTest.java
@@ -38,7 +38,7 @@ public class EnrollmentUTest extends CanvasTestBase {
         
         Enrollment firstEnrollment = enrollments.get(0);
         Assert.assertEquals("Expected id in object to match id in json", 1, firstEnrollment.getId());
-        Assert.assertEquals("Expected userId in object to match userId in json", 38, (int) firstEnrollment.getUserId());
+        Assert.assertEquals("Expected userId in object to match userId in json", "38", firstEnrollment.getUserId());
         Assert.assertEquals("Expected type in object to match type in json", "StudentEnrollment", firstEnrollment.getType());
         Assert.assertEquals("Expected associatedUserID in object to match associatedUserID in json", 40, (int)firstEnrollment.getAssociatedUserId());
         Assert.assertEquals("Expected courseSectionId in object to match courseSectionId in json", "6546", firstEnrollment.getCourseSectionId());

--- a/src/test/java/edu/ksu/canvas/tests/course/DropCourseUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/DropCourseUTest.java
@@ -31,10 +31,10 @@ public class DropCourseUTest extends CanvasTestBase {
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentResponse.json");
         Enrollment enrollment = new Enrollment();
         enrollment.setCourseId(25);
-        enrollment.setUserId(78839);
+        enrollment.setUserId("78839");
         Optional<Enrollment> enrollmentResponse = enrollmentsWriter.enrollUser(enrollment);
         Assert.assertTrue(25==enrollmentResponse.get().getCourseId());
-        Assert.assertTrue(78839 == enrollmentResponse.get().getUserId());
+        Assert.assertEquals(enrollmentResponse.get().getUserId(),"78839");
         Assert.assertTrue(enrollmentResponse.get().getId()!=0);
     }
 
@@ -54,10 +54,10 @@ public class DropCourseUTest extends CanvasTestBase {
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentResponse.json");
         Enrollment enrollment = new Enrollment();
         enrollment.setCourseId(25);
-        enrollment.setUserId(78839);
+        enrollment.setUserId("78839");
         Optional<Enrollment> enrollmentResponse = enrollmentsWriter.writeAsSisUser(userId).enrollUser(enrollment);
         Assert.assertTrue(25==enrollmentResponse.get().getCourseId());
-        Assert.assertTrue(78839 == enrollmentResponse.get().getUserId());
+        Assert.assertEquals(enrollmentResponse.get().getUserId(),"78839");
         Assert.assertTrue(enrollmentResponse.get().getId()!=0);
     }
 
@@ -78,10 +78,10 @@ public class DropCourseUTest extends CanvasTestBase {
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentResponse.json");
         Enrollment enrollment = new Enrollment();
         enrollment.setCourseId(25);
-        enrollment.setUserId(78839);
+        enrollment.setUserId("78839");
         Optional<Enrollment> enrollmentResponse = enrollmentsWriter.writeAsCanvasUser(userId).enrollUser(enrollment);
         Assert.assertTrue(25==enrollmentResponse.get().getCourseId());
-        Assert.assertTrue(78839 == enrollmentResponse.get().getUserId());
+        Assert.assertEquals(enrollmentResponse.get().getUserId(),"78839");
         Assert.assertTrue(enrollmentResponse.get().getId()!=0);
     }
 


### PR DESCRIPTION
Hello, 2 changes we'd like to get merged. The first is just Login support, nothing special. The second changes the Enrollment.userId field from an Integer to a String, so this is a bit of a breaking change. The requirement is to support SIS ID prefixes, e.g. sis_integration_id:somevalue. Alternatively I could add a new property of type String and move the annotation to it, and then have the old property parse it. Then old code could still compile and work fine, but it introduces a bit of cruft into the API. Let me know what you prefer.