### PR TITLE
Implementing equals and hashCode

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/Enrollment.java
+++ b/src/main/java/edu/ksu/canvas/model/Enrollment.java
@@ -5,6 +5,7 @@ import edu.ksu.canvas.annotation.CanvasObject;
 
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
 
 /**
  * Class to represent Canvas enrollments.
@@ -12,7 +13,7 @@ import java.util.Date;
  */
 @CanvasObject(postKey = "enrollment")
 public class Enrollment extends BaseCanvasModel implements Serializable {
-    public static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 2L;
 
     private long id;
     private Integer courseId;
@@ -236,5 +237,29 @@ public class Enrollment extends BaseCanvasModel implements Serializable {
 
     public void setUser(User user) {
         this.user = user;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Enrollment)) return false;
+        Enrollment that = (Enrollment) o;
+        // Use only attributes that can always be seen
+        return Objects.equals(courseId, that.courseId) &&
+                Objects.equals(courseSectionId, that.courseSectionId) &&
+                Objects.equals(enrollmentState, that.enrollmentState) &&
+                Objects.equals(limitPrivilegesToCourseSection, that.limitPrivilegesToCourseSection) &&
+                Objects.equals(rootAccountId, that.rootAccountId) &&
+                Objects.equals(type, that.type) &&
+                Objects.equals(userId, that.userId) &&
+                Objects.equals(associatedUserId, that.associatedUserId) &&
+                Objects.equals(role, that.role) &&
+                Objects.equals(user, that.user) &&
+                Objects.equals(roleId, that.roleId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(courseId, courseSectionId, enrollmentState, limitPrivilegesToCourseSection, rootAccountId, type, userId, associatedUserId, role, user, roleId);
     }
 }

--- a/src/main/java/edu/ksu/canvas/model/User.java
+++ b/src/main/java/edu/ksu/canvas/model/User.java
@@ -5,6 +5,7 @@ import edu.ksu.canvas.annotation.CanvasObject;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Class to represent Canvas users.
@@ -12,7 +13,7 @@ import java.util.List;
  */
 @CanvasObject(postKey = "user")
 public class User extends BaseCanvasModel implements Serializable {
-    public static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 1L;
 
     private int id;
     private String name;
@@ -157,5 +158,18 @@ public class User extends BaseCanvasModel implements Serializable {
 
     public void setBio(String bio) {
         this.bio = bio;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof User)) return false;
+        User user = (User) o;
+        return id == user.id && Objects.equals(name, user.name) && Objects.equals(sortableName, user.sortableName) && Objects.equals(shortName, user.shortName) && Objects.equals(loginId, user.loginId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, sortableName, shortName, loginId);
     }
 }


### PR DESCRIPTION
This is to allow you to use Enrollment objects in a java Set and have it eliminate duplicates correctly. I used only fields that would always be present, since some require an admin oAuth token to see and we could end up comparing a copy of the Enrollment we retrieved with an Admin token against one where we didn't use an admin Token and we'd want them to match.
I chose to not use the enrollmentId, because while matching enrollmentId values would definitely indicate a match, non-matching ids (especially with a null value) don't necessarily indicate either way, because we want to be also be able use this to prevent duplicate values where either or both are not yet persisted and so they wouldn't have an enrollment_id. Although I'm not sure that's actually possible considering we get them via Canvas api, but this is my standard way of implementing equals and hashcode so I'm just going to do it this way anyway.
This was needed for Teval, which is already making use of a `Set<Enrollment>` in its roster update code.
Leankit ID 300