### PR TITLE
Allow null values to be serialized to Canvas

### DIFF
--- a/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
+++ b/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
@@ -92,8 +92,10 @@ public class CanvasApiFactory {
 
         LOG.debug("got class: " + concreteClass);
         try {
-            Constructor<T> constructor = concreteClass.getConstructor(String.class, Integer.class, OauthToken.class, RestClient.class, Integer.TYPE, Integer.TYPE, Integer.class);
-            return constructor.newInstance(canvasBaseUrl, CANVAS_API_VERSION, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+            Constructor<T> constructor = concreteClass.getConstructor(String.class, Integer.class,
+                    OauthToken.class, RestClient.class, Integer.TYPE, Integer.TYPE, Integer.class, Boolean.class);
+            return constructor.newInstance(canvasBaseUrl, CANVAS_API_VERSION, oauthToken, restClient,
+                    connectTimeout, readTimeout, paginationPageSize, false);
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
             throw new UnsupportedOperationException("Unknown error instantiating the concrete API class: " + type.getName(), e);
         }
@@ -107,6 +109,20 @@ public class CanvasApiFactory {
      * @return A writer implementation class
      */
     public <T extends CanvasWriter> T getWriter(Class<T> type, OauthToken oauthToken) {
+        return getWriter(type, oauthToken, false);
+    }
+
+    /**
+     * Get a writer implementation to push data into Canvas while being able to control the behavior of blank values.
+     * If the serializeNulls parameter is set to true, this writer will serialize null fields in the JSON being
+     * sent to Canvas. This is required if you want to explicitly blank out a value that is currently set to something.
+     * @param type Interface type you wish to get an implementation for
+     * @param oauthToken An OAuth token to use for authentication when making API calls
+     * @param serializeNulls Whether or not to include null fields in the serialized JSON. Defaults to false if null
+     * @param <T> A writer implementation
+     * @return An instantiated instance of the requested writer type
+     */
+    public <T extends CanvasWriter> T getWriter(Class<T> type, OauthToken oauthToken, Boolean serializeNulls) {
         LOG.debug("Factory call to instantiate class: " + type.getName());
         RestClient restClient = new RefreshingRestClient();
 
@@ -117,10 +133,12 @@ public class CanvasApiFactory {
             throw new UnsupportedOperationException("No implementation for requested interface found: " + type.getName());
         }
 
-        LOG.debug("got class: " + concreteClass);
+        LOG.debug("got writer class: " + concreteClass);
         try {
-            Constructor<T> constructor = concreteClass.getConstructor(String.class, Integer.class, OauthToken.class, RestClient.class, Integer.TYPE, Integer.TYPE, Integer.class);
-            return constructor.newInstance(canvasBaseUrl, CANVAS_API_VERSION, oauthToken, restClient, connectTimeout, readTimeout, null);
+            Constructor<T> constructor = concreteClass.getConstructor(String.class, Integer.class, OauthToken.class,
+                    RestClient.class, Integer.TYPE, Integer.TYPE, Integer.class, Boolean.class);
+            return constructor.newInstance(canvasBaseUrl, CANVAS_API_VERSION, oauthToken, restClient,
+                    connectTimeout, readTimeout, null, serializeNulls);
         } catch (NoSuchMethodException | InvocationTargetException | IllegalAccessException | InstantiationException e) {
             throw new UnsupportedOperationException("Unknown error instantiating the concrete API class: " + type.getName(), e);
         }

--- a/src/main/java/edu/ksu/canvas/impl/AccountImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AccountImpl.java
@@ -23,8 +23,10 @@ import java.util.Optional;
 public class AccountImpl extends BaseImpl<Account, AccountReader, CanvasWriter> implements AccountReader {
     private static final Logger LOG = Logger.getLogger(AccountImpl.class);
 
-    public AccountImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public AccountImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                       int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/AdminImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AdminImpl.java
@@ -17,8 +17,10 @@ import java.util.List;
 public class AdminImpl extends BaseImpl<AccountAdmin, AdminReader, AdminWriter> implements AdminReader, AdminWriter {
     private static final Logger LOG = Logger.getLogger(AdminImpl.class);
 
-    public AdminImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public AdminImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                     int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/AssignmentGroupImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentGroupImpl.java
@@ -31,9 +31,12 @@ public class AssignmentGroupImpl extends BaseImpl<AssignmentGroup, AssignmentGro
      * @param connectTimeout     Timeout in seconds to use when connecting
      * @param readTimeout        Timeout in seconds to use when waiting for data to come back from an open connection
      * @param paginationPageSize How many objects to request per page on paginated requests
+     * @param serializeNulls     Whether or not to include null fields in the serialized JSON. Defaults to false if null
      */
-    public AssignmentGroupImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public AssignmentGroupImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                               int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     private static final Logger LOG = Logger.getLogger(AssignmentGroupImpl.class);

--- a/src/main/java/edu/ksu/canvas/impl/AssignmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentImpl.java
@@ -26,8 +26,10 @@ import java.util.Optional;
 public class AssignmentImpl extends BaseImpl<Assignment, AssignmentReader, AssignmentWriter> implements AssignmentReader, AssignmentWriter{
     private static final Logger LOG = Logger.getLogger(AssignmentReader.class);
 
-    public AssignmentImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public AssignmentImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                          int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -54,7 +56,7 @@ public class AssignmentImpl extends BaseImpl<Assignment, AssignmentReader, Assig
             throw new IllegalArgumentException("Assignment must have a name");
         }
         String url = buildCanvasUrl("courses/" + courseId + "/assignments", Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, assignment.toJsonObject());
+        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, assignment.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Assignment.class, response);
     }
 
@@ -75,7 +77,7 @@ public class AssignmentImpl extends BaseImpl<Assignment, AssignmentReader, Assig
     @Override
     public Optional<Assignment> editAssignment(String courseId, Assignment assignment) throws IOException {
         String url = buildCanvasUrl("courses/" + courseId + "/assignments/" + assignment.getId(), Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, assignment.toJsonObject());
+        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, assignment.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Assignment.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/AssignmentOverrideImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentOverrideImpl.java
@@ -21,8 +21,10 @@ public class AssignmentOverrideImpl extends BaseImpl<AssignmentOverride, Assignm
     private static final Logger LOG = Logger.getLogger(AssignmentOverrideImpl.class);
 
 
-    public AssignmentOverrideImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public AssignmentOverrideImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                                  int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -32,7 +34,7 @@ public class AssignmentOverrideImpl extends BaseImpl<AssignmentOverride, Assignm
         }
         LOG.debug("Creating an assignment override in course " + courseId + " for assignment " + assignmentOverride.getAssignmentId());
         String url = buildCanvasUrl("courses/" + courseId + "/assignments/" + assignmentOverride.getAssignmentId() + "/overrides", Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, assignmentOverride.toJsonObject());
+        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, assignmentOverride.toJsonObject(serializeNulls));
         return responseParser.parseToObject(AssignmentOverride.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/BaseImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/BaseImpl.java
@@ -12,6 +12,7 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.util.CanvasURLBuilder;
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -43,6 +44,7 @@ public abstract class BaseImpl<T, READERTYPE extends CanvasReader, WRITERTYPE ex
     protected String masqueradeAs;
     protected String masqueradeType;
     protected Integer paginationPageSize;
+    protected Boolean serializeNulls = false;
 
     /**
      * Construct a new CanvasApi class with an OAuth token
@@ -53,12 +55,15 @@ public abstract class BaseImpl<T, READERTYPE extends CanvasReader, WRITERTYPE ex
      * @param connectTimeout Timeout in seconds to use when connecting
      * @param readTimeout Timeout in seconds to use when waiting for data to come back from an open connection
      * @param paginationPageSize How many objects to request per page on paginated requests
+     * @param serializeNulls Whether or not to include null fields in the serialized JSON. Defaults to false if null
      */
-    public BaseImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
+    public BaseImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                    int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
         this.canvasBaseUrl = canvasBaseUrl;
         this.apiVersion = apiVersion;
         this.oauthToken = oauthToken;
         this.paginationPageSize = paginationPageSize;
+        this.serializeNulls = BooleanUtils.isTrue(serializeNulls);
         responseParser = new GsonResponseParser();
         canvasMessenger = new RestCanvasMessenger(connectTimeout, readTimeout, restClient);
     }

--- a/src/main/java/edu/ksu/canvas/impl/ConversationImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/ConversationImpl.java
@@ -25,8 +25,9 @@ public class ConversationImpl extends BaseImpl<Conversation, ConversationReader,
     private static final Logger LOG = Logger.getLogger(ConversationImpl.class);
 
     public ConversationImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
-            int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout,readTimeout, paginationPageSize);
+                            int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -67,7 +68,7 @@ public class ConversationImpl extends BaseImpl<Conversation, ConversationReader,
     public Optional<Conversation> editConversation(Conversation conversation) throws IOException {
         LOG.debug("Editing conversation: " + conversation.getId());
         String url = buildCanvasUrl("conversations/" + conversation.getId(), Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, conversation.toJsonObject());
+        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, conversation.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Conversation.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
@@ -26,8 +26,10 @@ import java.util.Optional;
 public class CourseImpl extends BaseImpl<Course, CourseReader, CourseWriter> implements CourseReader, CourseWriter {
     private static final Logger LOG = Logger.getLogger(CourseReader.class);
 
-    public CourseImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public CourseImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                      int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -64,7 +66,7 @@ public class CourseImpl extends BaseImpl<Course, CourseReader, CourseWriter> imp
     public Optional<Course> createCourse(String accountId, Course course) throws IOException {
         LOG.debug("creating course");
         String url = buildCanvasUrl("accounts/" + accountId + "/courses", Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, course.toJsonObject());
+        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, course.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Course.class, response);
     }
 
@@ -72,7 +74,7 @@ public class CourseImpl extends BaseImpl<Course, CourseReader, CourseWriter> imp
     public Optional<Course> updateCourse(Course course) throws IOException {
         LOG.debug("updating course");
         String url = buildCanvasUrl("courses/" + course.getId(), Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, course.toJsonObject());
+        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, course.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Course.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
@@ -26,8 +26,10 @@ import java.util.Optional;
 public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, EnrollmentWriter> implements EnrollmentReader,EnrollmentWriter {
     private static final Logger LOG = Logger.getLogger(CourseReader.class);
 
-    public EnrollmentImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public EnrollmentImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                          int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentTermImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentTermImpl.java
@@ -21,8 +21,10 @@ import java.util.stream.Collectors;
 public class EnrollmentTermImpl extends BaseImpl<EnrollmentTerm, EnrollmentTermReader, EnrollmentTermWriter> implements EnrollmentTermReader, EnrollmentTermWriter {
     private static final Logger LOG = Logger.getLogger(EnrollmentTermReader.class);
 
-    public EnrollmentTermImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public EnrollmentTermImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                              int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -44,7 +46,7 @@ public class EnrollmentTermImpl extends BaseImpl<EnrollmentTerm, EnrollmentTermR
     }
 
     private List<EnrollmentTerm> parseEnrollmentTermList(final Response response) {
-        EnrollmentTermWrapper wrapper = GsonResponseParser.getDefaultGsonParser().fromJson(response.getContent(), EnrollmentTermWrapper.class);
+        EnrollmentTermWrapper wrapper = GsonResponseParser.getDefaultGsonParser(serializeNulls).fromJson(response.getContent(), EnrollmentTermWrapper.class);
         return wrapper.getEnrollmentTerms();
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/ExternalToolImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/ExternalToolImpl.java
@@ -25,8 +25,10 @@ import edu.ksu.canvas.requestOptions.ListExternalToolsOptions;
 public class ExternalToolImpl extends BaseImpl<ExternalTool, ExternalToolReader, ExternalToolWriter> implements ExternalToolReader, ExternalToolWriter {
     private static final Logger LOG = Logger.getLogger(ExternalToolImpl.class);
 
-    public ExternalToolImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public ExternalToolImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                            int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -85,7 +87,7 @@ public class ExternalToolImpl extends BaseImpl<ExternalTool, ExternalToolReader,
 
     private Optional<ExternalTool> createExternalTool(String url, ExternalTool tool) throws IOException {
         ensureToolValidForCreation(tool);
-        Gson gson = GsonResponseParser.getDefaultGsonParser();
+        Gson gson = GsonResponseParser.getDefaultGsonParser(serializeNulls);
         JsonObject toolJson = gson.toJsonTree(tool).getAsJsonObject();
         Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, toolJson);
         return responseParser.parseToObject(ExternalTool.class, response);
@@ -109,7 +111,7 @@ public class ExternalToolImpl extends BaseImpl<ExternalTool, ExternalToolReader,
         if(tool.getId() == null) {
             throw new IllegalArgumentException("Tool being edited must have a tool ID");
         }
-        Gson gson = GsonResponseParser.getDefaultGsonParser();
+        Gson gson = GsonResponseParser.getDefaultGsonParser(serializeNulls);
         JsonObject toolJson = gson.toJsonTree(tool).getAsJsonObject();
         Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, toolJson);
         return responseParser.parseToObject(ExternalTool.class, response);

--- a/src/main/java/edu/ksu/canvas/impl/GsonResponseParser.java
+++ b/src/main/java/edu/ksu/canvas/impl/GsonResponseParser.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 
@@ -34,26 +35,29 @@ public class GsonResponseParser implements ResponseParser {
 
     @Override
     public <T> List<T> parseToList(Type type, Response response) {
-        Gson gson = getDefaultGsonParser();
+        Gson gson = getDefaultGsonParser(false);
         return gson.fromJson(response.getContent(), type);
     }
 
     @Override
     public <T> Optional<T> parseToObject(Class<T> clazz, Response response) {
-        Gson gson = getDefaultGsonParser();
+        Gson gson = getDefaultGsonParser(false);
         return Optional.of(gson.fromJson(response.getContent(), clazz));
     }
 
     @Override
     public <T> Map<String, T> parseToMap(Class<T> clazz, Response response) {
-        Gson gson = getDefaultGsonParser();
+        Gson gson = getDefaultGsonParser(false);
         Type mapType = new TypeToken<Map<String,T>>(){}.getType();
         return gson.fromJson(response.getContent(), mapType);
     }
 
-    public static Gson getDefaultGsonParser() {
+    public static Gson getDefaultGsonParser(Boolean serializeNulls) {
         GsonBuilder gsonBuilder = new GsonBuilder();
         gsonBuilder.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES);
+        if(BooleanUtils.isTrue(serializeNulls)) {
+            gsonBuilder.serializeNulls();
+        }
         //Custom type adapter for Date because: GSON throws a parse exception for blank dates instead of returning null.
         //Also, it doesn't handle ISO 8601 dates with time zone info. Dates are hard.
         gsonBuilder.registerTypeAdapter(Date.class, new JsonDeserializer<Date>() {

--- a/src/main/java/edu/ksu/canvas/impl/LoginImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/LoginImpl.java
@@ -19,8 +19,9 @@ public class LoginImpl extends BaseImpl<Login, LoginReader, LoginWriter> impleme
     private static final Logger LOG = Logger.getLogger(LoginImpl.class);
 
     public LoginImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
-            int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+                     int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/PageImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/PageImpl.java
@@ -22,8 +22,10 @@ import edu.ksu.canvas.oauth.OauthToken;
 public class PageImpl extends BaseImpl<Page, PageReader, PageWriter> implements PageReader, PageWriter {
     private static final Logger LOG = Logger.getLogger(PageImpl.class);
 
-    public PageImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public PageImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                    int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -49,7 +51,7 @@ public class PageImpl extends BaseImpl<Page, PageReader, PageWriter> implements 
         LOG.debug("Updating page in course" + courseId);
         String encodedUrl = URLEncoder.encode(page.getUrl(), CanvasConstants.URLENCODING_TYPE);
         String url = buildCanvasUrl("courses/" + courseId + "/pages/" + encodedUrl, Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, page.toJsonObject());
+        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, page.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Page.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/QuizImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizImpl.java
@@ -20,8 +20,10 @@ import java.util.stream.Collectors;
 public class QuizImpl extends BaseImpl<Quiz, QuizReader, QuizWriter> implements QuizReader, QuizWriter {
     private static final Logger LOG = Logger.getLogger(QuizReader.class);
 
-    public QuizImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public QuizImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                    int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -44,7 +46,7 @@ public class QuizImpl extends BaseImpl<Quiz, QuizReader, QuizWriter> implements 
     public Optional<Quiz> updateQuiz(Quiz quiz, String courseId) throws IOException {
         LOG.debug("Updating quiz " + quiz.getId() + " in course " + courseId);
         String url = buildCanvasUrl("courses/" + courseId + "/quizzes/" + quiz.getId(), Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url,quiz.toJsonObject());
+        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url,quiz.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Quiz.class, response);
     }
 
@@ -57,7 +59,7 @@ public class QuizImpl extends BaseImpl<Quiz, QuizReader, QuizWriter> implements 
 
     private List<Quiz> parseQuizList(final Response response) {
         Type listType = new TypeToken<List<Quiz>>(){}.getType();
-        return GsonResponseParser.getDefaultGsonParser().fromJson(response.getContent(), listType);
+        return GsonResponseParser.getDefaultGsonParser(serializeNulls).fromJson(response.getContent(), listType);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/QuizQuestionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizQuestionImpl.java
@@ -19,8 +19,10 @@ import java.util.List;
 public class QuizQuestionImpl extends BaseImpl<QuizQuestion, QuizQuestionReader, QuizQuestionWriter> implements QuizQuestionReader, QuizQuestionWriter {
     private static final Logger LOG = Logger.getLogger(QuizQuestionImpl.class);
 
-    public QuizQuestionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimout, paginationPageSize);
+    public QuizQuestionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                            int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/QuizSubmissionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizSubmissionImpl.java
@@ -23,8 +23,10 @@ import java.util.stream.Collectors;
 public class QuizSubmissionImpl extends BaseImpl<QuizSubmission, QuizSubmissionReader, QuizSubmissionWriter> implements QuizSubmissionReader, QuizSubmissionWriter {
     private static final Logger LOG = Logger.getLogger(QuizSubmissionImpl.class);
 
-     public QuizSubmissionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-         super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+     public QuizSubmissionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                               int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+         super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                 paginationPageSize, serializeNulls);
      }
 
     @Override
@@ -60,7 +62,7 @@ public class QuizSubmissionImpl extends BaseImpl<QuizSubmission, QuizSubmissionR
     }
 
     private List<QuizSubmission> parseQuizSubmissionList(final Response response) {
-        QuizSubmissionListWrapper wrapper = GsonResponseParser.getDefaultGsonParser().fromJson(response.getContent(), QuizSubmissionListWrapper.class);
+        QuizSubmissionListWrapper wrapper = GsonResponseParser.getDefaultGsonParser(serializeNulls).fromJson(response.getContent(), QuizSubmissionListWrapper.class);
         return wrapper.getQuiz_submissions();
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/QuizSubmissionQuestionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizSubmissionQuestionImpl.java
@@ -32,8 +32,10 @@ import java.util.List;
 public class QuizSubmissionQuestionImpl extends BaseImpl<QuizSubmissionQuestion, QuizSubmissionQuestionReader, QuizSubmissionQuestionWriter> implements QuizSubmissionQuestionReader, QuizSubmissionQuestionWriter {
     private static final Logger LOG = Logger.getLogger(QuizSubmissionQuestionImpl.class);
 
-    public QuizSubmissionQuestionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public QuizSubmissionQuestionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                                      int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/RoleImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/RoleImpl.java
@@ -17,8 +17,10 @@ import java.util.List;
 public class RoleImpl extends BaseImpl<Role, RoleReader, RoleWriter> implements RoleReader, RoleWriter {
     private static final Logger LOG = Logger.getLogger(RoleImpl.class);
 
-    public RoleImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public RoleImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                    int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/SectionsImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/SectionsImpl.java
@@ -28,8 +28,10 @@ public class SectionsImpl extends BaseImpl<Section, SectionReader, SectionWriter
 
     private static final Logger LOG = Logger.getLogger(SectionReader.class);
 
-    public SectionsImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public SectionsImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                        int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -69,7 +71,7 @@ public class SectionsImpl extends BaseImpl<Section, SectionReader, SectionWriter
             params.put("enable_sis_reactivation", Arrays.asList(Boolean.toString(enableSisReactivation)));
         }
         String url = buildCanvasUrl(String.format("/courses/%s/sections", courseId), params);
-        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, section.toJsonObject());
+        Response response = canvasMessenger.sendJsonPostToCanvas(oauthToken, url, section.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Section.class, response);
     }
 
@@ -77,7 +79,7 @@ public class SectionsImpl extends BaseImpl<Section, SectionReader, SectionWriter
     public Optional<Section> updateSection(Section section) throws IOException {
         LOG.debug("updating section " + section.getId());
         String url = buildCanvasUrl("sections/" + section.getId(), Collections.emptyMap());
-        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, section.toJsonObject());
+        Response response = canvasMessenger.sendJsonPutToCanvas(oauthToken, url, section.toJsonObject(serializeNulls));
         return responseParser.parseToObject(Section.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/SubmissionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/SubmissionImpl.java
@@ -32,9 +32,12 @@ public class SubmissionImpl extends BaseImpl<Submission, SubmissionReader, Submi
      * @param connectTimeout     Timeout in seconds to use when connecting
      * @param readTimeout        Timeout in seconds to use when waiting for data to come back from an open connection
      * @param paginationPageSize How many objects to request per page on paginated requests
+     * @param serializeNulls     Whether or not to include null fields in the serialized JSON. Defaults to false if null
      */
-    public SubmissionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public SubmissionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                          int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override
@@ -56,7 +59,7 @@ public class SubmissionImpl extends BaseImpl<Submission, SubmissionReader, Submi
     }
 
     private Optional<Progress> gradeMultipleSubmissions(MultipleSubmissionsOptions options, String url) throws IOException {
-        Gson gson = GsonResponseParser.getDefaultGsonParser();
+        Gson gson = GsonResponseParser.getDefaultGsonParser(serializeNulls);
         JsonObject jsonObject = new JsonObject();
         jsonObject.add("grade_data", gson.toJsonTree(options.getStudentSubmissionOptionMap()));
 
@@ -69,7 +72,7 @@ public class SubmissionImpl extends BaseImpl<Submission, SubmissionReader, Submi
     }
 
     private Progress parseSubmissionResponse(final Response response) {
-        return GsonResponseParser.getDefaultGsonParser().fromJson(response.getContent(), Progress.class);
+        return GsonResponseParser.getDefaultGsonParser(serializeNulls).fromJson(response.getContent(), Progress.class);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/impl/UserImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/UserImpl.java
@@ -25,8 +25,10 @@ import java.util.Optional;
 public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements UserReader, UserWriter{
     private static final Logger LOG = Logger.getLogger(UserImpl.class);
 
-    public UserImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize);
+    public UserImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
+                    int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
+                paginationPageSize, serializeNulls);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/model/BaseCanvasModel.java
+++ b/src/main/java/edu/ksu/canvas/model/BaseCanvasModel.java
@@ -53,16 +53,17 @@ public abstract class BaseCanvasModel {
      * can be pushed to Canvas create/edit endpoints. For example, to create an assignment, the JSON
      * must look like: <pre>{assignment: {name: "Assignment 1"}}</pre>.
      * This method adds the outer "assignment" container based on CanvasObject notations on the model classes
+     * @param serializeNulls Whether or not to include null fields in the serialized JSON. Defaults to false if null
      * @return A JsonObject suitable for serializing out to the Canvas API
      */
-    public JsonObject toJsonObject() {
+    public JsonObject toJsonObject(Boolean serializeNulls) {
         Class<? extends BaseCanvasModel> clazz = this.getClass();
         CanvasObject canvasObjectAnnotation = clazz.getAnnotation(CanvasObject.class);
         if(canvasObjectAnnotation == null || canvasObjectAnnotation.postKey() == null) {
             throw new IllegalArgumentException("Object to wrap must have a CanvasObject annotation with a postKey");
         }
         String objectPostKey = canvasObjectAnnotation.postKey();
-        JsonElement element = GsonResponseParser.getDefaultGsonParser().toJsonTree(this);
+        JsonElement element = GsonResponseParser.getDefaultGsonParser(serializeNulls).toJsonTree(this);
         JsonObject jsonObject = new JsonObject();
         jsonObject.add(objectPostKey, element);
         return jsonObject;

--- a/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
@@ -259,7 +259,7 @@ public class SimpleRestClient implements RestClient {
     private String extractErrorMessageFromResponse(HttpResponse response) {
         String contentType = response.getEntity().getContentType().getValue();
         if(contentType.contains("application/json")) {
-            Gson gson = GsonResponseParser.getDefaultGsonParser();
+            Gson gson = GsonResponseParser.getDefaultGsonParser(false);
             String responseBody = null;
             try {
                 responseBody = EntityUtils.toString(response.getEntity());

--- a/src/main/java/edu/ksu/canvas/oauth/OauthTokenRefresher.java
+++ b/src/main/java/edu/ksu/canvas/oauth/OauthTokenRefresher.java
@@ -60,7 +60,7 @@ public class OauthTokenRefresher implements Serializable {
         }
         HttpEntity entity = httpResponse.getEntity();
         String responseBody = EntityUtils.toString(entity);
-        Gson gson = GsonResponseParser.getDefaultGsonParser();
+        Gson gson = GsonResponseParser.getDefaultGsonParser(false);
         return gson.fromJson(responseBody, TokenRefreshResponse.class);
     }
 }

--- a/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
+++ b/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
@@ -102,7 +102,7 @@ public class BaseCanvasModelUTest {
         TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField1(FIELD1_VALUE);
 
-        JsonObject jsonObject = canvasModel.toJsonObject();
+        JsonObject jsonObject = canvasModel.toJsonObject(false);
         JsonElement element = jsonObject.get(CLASS_POST_KEY);
 
         Assert.assertNotNull("JSON object should have a top level element: " + CLASS_POST_KEY, element);
@@ -113,7 +113,7 @@ public class BaseCanvasModelUTest {
         TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField1(FIELD1_VALUE);
 
-        JsonObject jsonObject = canvasModel.toJsonObject();
+        JsonObject jsonObject = canvasModel.toJsonObject(false);
         JsonElement element = jsonObject.get(CLASS_POST_KEY);
         JsonObject field1Obj = element.getAsJsonObject();
         String field1Value = field1Obj.get("field1").getAsString();

--- a/src/test/java/edu/ksu/canvas/EnrollmentTermUTest.java
+++ b/src/test/java/edu/ksu/canvas/EnrollmentTermUTest.java
@@ -28,7 +28,7 @@ public class EnrollmentTermUTest extends CanvasTestBase {
     public void setup() {
         String url =  baseUrl  + "/api/v1/accounts/" + ACCOUNT_ID + "/terms";
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentTerm.json");
-        enrollmentTermReader = new EnrollmentTermImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        enrollmentTermReader = new EnrollmentTermImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/EnrollmentUTest.java
+++ b/src/test/java/edu/ksu/canvas/EnrollmentUTest.java
@@ -29,7 +29,7 @@ public class EnrollmentUTest extends CanvasTestBase {
     public void setup() {
         String url =  baseUrl  + "/api/v1/sections/" + SECTION_ID + "/enrollments?type[]=StudentEnrollment";
         fakeRestClient.addSuccessResponse(url, "SampleJson/Enrollments.json");
-        enrollmentsReader = new EnrollmentImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        enrollmentsReader = new EnrollmentImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
     
     @Test

--- a/src/test/java/edu/ksu/canvas/TestCanvasReaderImpl.java
+++ b/src/test/java/edu/ksu/canvas/TestCanvasReaderImpl.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 public class TestCanvasReaderImpl extends BaseImpl<TestCanvasModel, TestCanvasReader, TestCanvasWriter> implements TestCanvasReader {
 
     public TestCanvasReaderImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout) {
-        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, CanvasTestBase.DEFAULT_PAGINATION_PAGE_SIZE);
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, CanvasTestBase.DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     public List<TestCanvasModel> getTestModels(String url) throws IOException {

--- a/src/test/java/edu/ksu/canvas/impl/SubmissionImplTest.java
+++ b/src/test/java/edu/ksu/canvas/impl/SubmissionImplTest.java
@@ -32,7 +32,7 @@ public class SubmissionImplTest extends CanvasTestBase {
     public void setup() {
         String url =  baseUrl  + "/api/v1/sections/" + SECTION_ID + "/assignments/" + ASSIGNEMNET_ID + "/submissions/update_grades";
         fakeRestClient.addSuccessResponse(url, "SampleJson/Progress.json");
-        submissionWriter = new SubmissionImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        submissionWriter = new SubmissionImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/account/AccountReaderUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/account/AccountReaderUTest.java
@@ -31,7 +31,8 @@ public class AccountReaderUTest extends CanvasTestBase {
 
     @Before
     public void setupReader() {
-        accountReader = new AccountImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        accountReader = new AccountImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentGroupUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentGroupUTest.java
@@ -27,7 +27,8 @@ public class AssignmentGroupUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        reader = new AssignmentGroupImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        reader = new AssignmentGroupImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentRetrieverUTest.java
@@ -28,7 +28,8 @@ public class AssignmentRetrieverUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        assignmentReader = new AssignmentImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        assignmentReader = new AssignmentImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
 

--- a/src/test/java/edu/ksu/canvas/tests/course/CourseListingUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/CourseListingUTest.java
@@ -25,7 +25,8 @@ public class CourseListingUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        courseReader = new CourseImpl(baseUrl,apiVersion,SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        courseReader = new CourseImpl(baseUrl,apiVersion,SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/course/CourseManagerUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/CourseManagerUTest.java
@@ -25,7 +25,8 @@ public class CourseManagerUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        courseWriter = new CourseImpl(baseUrl,apiVersion,SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        courseWriter = new CourseImpl(baseUrl,apiVersion,SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/course/DropCourseUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/DropCourseUTest.java
@@ -21,7 +21,8 @@ public class DropCourseUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        enrollmentsWriter = new EnrollmentImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        enrollmentsWriter = new EnrollmentImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/course/SectionManagerUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/SectionManagerUTest.java
@@ -24,7 +24,7 @@ public class SectionManagerUTest extends CanvasTestBase {
     @Before
     public void setupData() {
         sectionWriter = new SectionsImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
-            SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+            SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/course/UserManagerUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/UserManagerUTest.java
@@ -21,7 +21,8 @@ public class UserManagerUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        userWriter = new UserImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        userWriter = new UserImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/gson/GsonDateParsingUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/gson/GsonDateParsingUTest.java
@@ -33,7 +33,7 @@ public class GsonDateParsingUTest extends CanvasTestBase {
 
     @Before
     public void setUpGson() {
-        gson = GsonResponseParser.getDefaultGsonParser();
+        gson = GsonResponseParser.getDefaultGsonParser(false);
         assignment = new Assignment();
         assignment.setName("Assignment 1");
     }

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizQuestionRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizQuestionRetrieverUTest.java
@@ -27,7 +27,8 @@ public class QuizQuestionRetrieverUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        quizQuestionReader = new QuizQuestionImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        quizQuestionReader = new QuizQuestionImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizRetrieverUTest.java
@@ -27,7 +27,8 @@ public class QuizRetrieverUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        quizReader = new QuizImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        quizReader = new QuizImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
@@ -26,7 +26,8 @@ public class QuizSubmissionRetrieverUTest extends CanvasTestBase {
 
     @Before
     public void setUpData() {
-        quizSubmissionReader = new QuizSubmissionImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        quizSubmissionReader = new QuizSubmissionImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/roles/RolesUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/roles/RolesUTest.java
@@ -24,7 +24,8 @@ public class RolesUTest extends CanvasTestBase {
     
     @Before
     public void setupReader() {
-         roleReader = new RoleImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+         roleReader = new RoleImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                 SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test

--- a/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
@@ -29,7 +29,8 @@ public class UserRetrieverUTest extends CanvasTestBase {
 
     @Before
     public void setupData() {
-        userReader = new UserImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT, SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE);
+        userReader = new UserImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
     }
 
     @Test


### PR DESCRIPTION
Gson can now be optionally configured to serialize null values when sending a post to Canvas.

One possible approach to addressing #67.