### PR TITLE
Change ListAccountAdminsOptions.includes from [int] to [String]

### DIFF
--- a/src/main/java/edu/ksu/canvas/requestOptions/BaseOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/BaseOptions.java
@@ -1,5 +1,6 @@
 package edu.ksu.canvas.requestOptions;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -29,5 +30,9 @@ public abstract class BaseOptions {
 
     protected void addNumberList(String key, List<? extends Number> list) {
         optionsMap.put(key, list.stream().map(i->i.toString()).collect(Collectors.toList()));
+    }
+
+    protected void addStringList(String key, List<String> list) {
+        optionsMap.put(key, new ArrayList<String>(list));
     }
 }

--- a/src/main/java/edu/ksu/canvas/requestOptions/ListAccountAdminsOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/ListAccountAdminsOptions.java
@@ -13,8 +13,8 @@ public class ListAccountAdminsOptions extends BaseOptions {
         return accountId;
     }
 
-    public ListAccountAdminsOptions includes(List<Integer> userIds) {
-        addNumberList("user_id[]", userIds);
+    public ListAccountAdminsOptions includes(List<String> userIds) {
+        addStringList("user_id[]", userIds);
         return this;
     }
 }


### PR DESCRIPTION
The Canvas API accepts the SIS ID format for this parameter.

I just changed the existing method, which will break existing clients. Let me know if you'd prefer an additional method instead.