### PR TITLE
Don't wrap 5xx error in unchecked exception

### DIFF
--- a/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
@@ -225,7 +225,6 @@ public class SimpleRestClient implements RestClient {
         } catch (NullPointerException e) {
             LOG.debug("Rate not being limited: " + e);
         }
-
         if (statusCode == 401) {
             //If the WWW-Authenticate header is set, it is a token problem.
             //If the header is not present, it is a user permission error.
@@ -241,7 +240,8 @@ public class SimpleRestClient implements RestClient {
             LOG.error("Object not found in Canvas. Requested URL: " + request.getURI());
             throw new ObjectNotFoundException(extractErrorMessageFromResponse(httpResponse), String.valueOf(request.getURI()));
         }
-        if(statusCode < 200 || statusCode > 299) {
+        // If we receive a 5xx exception, we should not wrap it in an unchecked exception for upstream clients to deal with.
+        if(statusCode < 200 || (statusCode > 299 && statusCode <= 499)) {
             LOG.error("HTTP status " + statusCode + " returned from " + request.getURI());
             throw new CanvasException(extractErrorMessageFromResponse(httpResponse), String.valueOf(request.getURI()));
         }

--- a/src/test/java/edu/ksu/canvas/net/SimpleRestClientUTest.java
+++ b/src/test/java/edu/ksu/canvas/net/SimpleRestClientUTest.java
@@ -1,5 +1,8 @@
 package edu.ksu.canvas.net;
 
+import static org.junit.Assert.assertNull;
+
+import java.io.IOException;
 import java.util.Collections;
 
 import org.apache.http.HttpHeaders;
@@ -12,6 +15,7 @@ import edu.ksu.canvas.exception.InvalidOauthTokenException;
 import edu.ksu.canvas.exception.UnauthorizedException;
 import edu.ksu.canvas.oauth.NonRefreshableOauthToken;
 import edu.ksu.canvas.oauth.OauthToken;
+
 
 
 @RunWith(JUnit4.class)
@@ -34,5 +38,14 @@ public class SimpleRestClientUTest extends LocalServerTestBase {
         registerUrlResponse(url, "/SampleJson/oauth/InvalidAccessTokenResponse.json", 401, Collections.singletonMap(HttpHeaders.WWW_AUTHENTICATE, ""));
 
         restClient.sendApiGet(emptyAdminToken, baseUrl + url, 100, 100);
+    }
+
+    @Test(expected = IOException.class)
+    public void http503ServiceTemporarilyUnavailableException() throws Exception {
+        String url = "/unavailableServiceUrl";
+        registerUrlResponse(url, "", 503, Collections.emptyMap());
+
+        final Response response = restClient.sendApiGet(emptyAdminToken, baseUrl + url, 100, 100);
+        assertNull(response.getContent());
     }
 }


### PR DESCRIPTION
The response handler will do the right thing in throwing (essentially) an IOException for upstream clients to deal with.