### PR TITLE
Support include[]=user on QuizSubmissionReader

### DIFF
--- a/src/main/java/edu/ksu/canvas/interfaces/QuizSubmissionReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/QuizSubmissionReader.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.List;
 
 import edu.ksu.canvas.model.assignment.QuizSubmission;
+import edu.ksu.canvas.model.assignment.QuizSubmissionResponse;
+import edu.ksu.canvas.requestOptions.GetQuizSubmissionsOptions;
 
 public interface QuizSubmissionReader extends CanvasReader<QuizSubmission, QuizSubmissionReader> {
     /**
@@ -14,5 +16,15 @@ public interface QuizSubmissionReader extends CanvasReader<QuizSubmission, QuizS
      * @throws IOException When there is an error communicating with Canvas
      */
     List<QuizSubmission> getQuizSubmissions(String courseId, String quizId) throws IOException;
+
+    /**
+     * Retrieve a list of quiz submissions from Canvas by its course and quiz Canvas ID numbers
+     *
+     * @param courseId The Canvas ID of the course
+     * @param quizId   The Canvas ID of the quiz
+     * @return List of quiz submissions in the course with the course ID
+     * @throws IOException When there is an error communicating with Canvas
+     */
+    QuizSubmissionResponse getQuizSubmissions(GetQuizSubmissionsOptions options) throws IOException;
 
 }

--- a/src/main/java/edu/ksu/canvas/model/assignment/QuizSubmissionResponse.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/QuizSubmissionResponse.java
@@ -15,7 +15,7 @@ public class QuizSubmissionResponse {
 
     public QuizSubmissionResponse(final List<QuizSubmission> quizSubmissions, final List<User> users) {
         this.quizSubmissions = ImmutableList.copyOf(quizSubmissions);
-        this.users = users.stream().collect(Collectors.toMap(User::getId, Function.identity()));
+        this.users = users.stream().distinct().collect(Collectors.toMap(User::getId, Function.identity()));
     }
 
     public List<QuizSubmission> getQuizSubmissions() {

--- a/src/main/java/edu/ksu/canvas/model/assignment/QuizSubmissionResponse.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/QuizSubmissionResponse.java
@@ -1,0 +1,33 @@
+package edu.ksu.canvas.model.assignment;
+
+import com.google.common.collect.ImmutableList;
+import edu.ksu.canvas.model.User;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public class QuizSubmissionResponse {
+    private final List<QuizSubmission> quizSubmissions;
+    private final Map<Integer, User> users;
+
+    public QuizSubmissionResponse(final List<QuizSubmission> quizSubmissions, final List<User> users) {
+        this.quizSubmissions = ImmutableList.copyOf(quizSubmissions);
+        this.users = users.stream().collect(Collectors.toMap(User::getId, Function.identity()));
+    }
+
+    public List<QuizSubmission> getQuizSubmissions() {
+        return quizSubmissions;
+    }
+
+    public Map<Integer, User> getUsers() {
+        return users;
+    }
+
+    public Optional<User> getUser(final int id) {
+        return Optional.ofNullable(users.get(id));
+    }
+
+}

--- a/src/main/java/edu/ksu/canvas/model/wrapper/QuizSubmissionWrapper.java
+++ b/src/main/java/edu/ksu/canvas/model/wrapper/QuizSubmissionWrapper.java
@@ -1,22 +1,33 @@
 package edu.ksu.canvas.model.wrapper;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import edu.ksu.canvas.model.User;
+import edu.ksu.canvas.model.assignment.QuizQuestion;
 import edu.ksu.canvas.model.assignment.QuizSubmission;
 
 /**
  * Wrapper class made necessary because canvas returns an object that
- * contains a list of QuizSubmission Objects, with only one item in the list.
- * Rather than either just a list, or just the object....
+ * contains a list of QuizSubmission objects, with supplemental objects
  */
 public class QuizSubmissionWrapper {
-    private List<QuizSubmission> quizSubmissions;
+    private List<QuizSubmission> quizSubmissions = new ArrayList<>();
+    private List<User> users = new ArrayList<>();
 
     public List<QuizSubmission> getQuizSubmissions() {
         return quizSubmissions;
     }
 
-    public void setQuizSubmissions(List<QuizSubmission> quizSubmissions) {
+    public void setQuizSubmissions(final List<QuizSubmission> quizSubmissions) {
         this.quizSubmissions = quizSubmissions;
+    }
+
+    public List<User> getUsers() {
+        return users;
+    }
+
+    public void setUsers(final List<User> users) {
+        this.users = users;
     }
 }

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetQuizSubmissionsOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetQuizSubmissionsOptions.java
@@ -1,0 +1,48 @@
+package edu.ksu.canvas.requestOptions;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetQuizSubmissionsOptions extends BaseOptions {
+    private String courseId;
+    private String quizId;
+
+    public enum Include {
+        USER;
+
+        public String toString() {
+            return name().toLowerCase();
+        }
+    }
+
+    public GetQuizSubmissionsOptions includes(final List<Include> includes) {
+        addEnumList("include[]", includes);
+        return this;
+    }
+
+    public GetQuizSubmissionsOptions(final String courseId, final String quizId, final Include... includes) {
+        this.courseId = courseId;
+        this.quizId = quizId;
+        if (includes.length > 0) {
+            includes(ImmutableList.copyOf(includes));
+        }
+    }
+
+    public String getCourseId() {
+        return courseId;
+    }
+
+    public void setCourseId(final String courseId) {
+        this.courseId = courseId;
+    }
+
+    public String getQuizId() {
+        return quizId;
+    }
+
+    public void setQuizId(final String quizId) {
+        this.quizId = quizId;
+    }
+}

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
@@ -6,8 +6,10 @@ import edu.ksu.canvas.constants.CanvasConstants;
 import edu.ksu.canvas.impl.QuizSubmissionImpl;
 import edu.ksu.canvas.interfaces.QuizSubmissionReader;
 import edu.ksu.canvas.model.assignment.QuizSubmission;
+import edu.ksu.canvas.model.assignment.QuizSubmissionResponse;
 import edu.ksu.canvas.net.FakeRestClient;
 import edu.ksu.canvas.net.Response;
+import edu.ksu.canvas.requestOptions.GetQuizSubmissionsOptions;
 import edu.ksu.canvas.util.CanvasURLBuilder;
 import org.apache.log4j.Logger;
 import org.junit.Assert;
@@ -59,7 +61,28 @@ public class QuizSubmissionRetrieverUTest extends CanvasTestBase {
 
         Assert.assertTrue(quizSubmissionReader.getQuizSubmissions(someCourseId, someQuizId).isEmpty());
     }
-    
+
+    @Test
+    public void testQuizSubmissions_includeUsers() throws Exception {
+        final String someCourseId = "25132";
+        final String someQuizId = "61279";
+        final Response notErroredResponse = new Response();
+        notErroredResponse.setErrorHappened(false);
+        notErroredResponse.setResponseCode(200);
+        final String url = baseUrl + "/api/v1/courses/" + someCourseId + "/quizzes/" + someQuizId + "/submissions?include[]=user";
+        fakeRestClient.addSuccessResponse(url, "SampleJson/quiz/QuizSubmissionsIncludeUser.json");
+        final GetQuizSubmissionsOptions options = new GetQuizSubmissionsOptions(someCourseId, someQuizId, GetQuizSubmissionsOptions.Include.USER);
+        final QuizSubmissionResponse response = quizSubmissionReader.getQuizSubmissions(options);
+
+        Assert.assertNotNull(response);
+        Assert.assertNotNull(response.getQuizSubmissions());
+        Assert.assertNotNull(response.getUsers());
+        Assert.assertEquals(2, response.getQuizSubmissions().size());
+        Assert.assertEquals(2, response.getUsers().size());
+        Assert.assertEquals((Integer) 508566, response.getQuizSubmissions().get(0).getId());
+        Assert.assertEquals("User 218826", response.getUser(218826).get().getName());
+    }
+
     @Test
     public void testSisUserMasqueradeRetrieveQuizSubmissions() throws Exception{
         String someUserId = "8991123123";

--- a/src/test/resources/SampleJson/quiz/QuizSubmissionsIncludeUser.json
+++ b/src/test/resources/SampleJson/quiz/QuizSubmissionsIncludeUser.json
@@ -1,0 +1,87 @@
+{
+  "quiz_submissions": [
+    {
+      "id": 508566,
+      "quiz_id": 61279,
+      "quiz_version": 5,
+      "user_id": 218824,
+      "submission_id": 7251043,
+      "score": 1,
+      "kept_score": 1,
+      "started_at": "2018-07-20T20:11:11Z",
+      "end_at": null,
+      "finished_at": "2018-07-20T20:11:18Z",
+      "attempt": 1,
+      "workflow_state": "complete",
+      "fudge_points": null,
+      "quiz_points_possible": 2,
+      "extra_attempts": null,
+      "extra_time": null,
+      "manually_unlocked": null,
+      "validation_token": "token508566",
+      "score_before_regrade": null,
+      "has_seen_results": false,
+      "time_spent": 7,
+      "attempts_left": -1,
+      "overdue_and_needs_submission": false,
+      "excused?": false,
+      "html_url": "https://instance.test.instructure.com/courses/25132/quizzes/61279/submissions/508566",
+      "result_url": "https://instance.test.instructure.com/courses/25132/quizzes/61279/history?quiz_submission_id=508566&version=1"
+    },
+    {
+      "id": 508565,
+      "quiz_id": 61279,
+      "quiz_version": 5,
+      "user_id": 218826,
+      "submission_id": 7251042,
+      "score": 0,
+      "kept_score": 0,
+      "started_at": "2018-07-20T18:50:34Z",
+      "end_at": null,
+      "finished_at": "2018-07-20T18:50:41Z",
+      "attempt": 1,
+      "workflow_state": "complete",
+      "fudge_points": null,
+      "quiz_points_possible": 2,
+      "extra_attempts": null,
+      "extra_time": null,
+      "manually_unlocked": null,
+      "validation_token": "token508565",
+      "score_before_regrade": null,
+      "has_seen_results": false,
+      "time_spent": 7,
+      "attempts_left": -1,
+      "overdue_and_needs_submission": false,
+      "excused?": false,
+      "html_url": "https://instance.test.instructure.com/courses/25132/quizzes/61279/submissions/508565",
+      "result_url": "https://instance.test.instructure.com/courses/25132/quizzes/61279/history?quiz_submission_id=508565&version=1"
+    }
+  ],
+  "users": [
+    {
+      "id": 218824,
+      "name": "User 218824",
+      "sortable_name": "User 218824",
+      "short_name": "User 218824",
+      "sis_user_id": null,
+      "integration_id": "integration218824",
+      "sis_import_id": null,
+      "login_id": "login218824",
+      "avatar_url": "https://instance.test.instructure.com/images/messages/avatar-50.png"
+    },
+    {
+      "id": 218826,
+      "name": "User 218826",
+      "sortable_name": "User 218826",
+      "short_name": "User 218826",
+      "sis_user_id": null,
+      "integration_id": "integration218826",
+      "sis_import_id": null,
+      "login_id": "login218826",
+      "avatar_url": "https://instance.test.instructure.com/images/messages/avatar-50.png"
+    }
+  ],
+  "meta": {
+    "primaryCollection": "quiz_submissions"
+  }
+}


### PR DESCRIPTION
This allows the relevant user records to be pulled at the same time as quiz submissions, which makes it possible to see who made each submission without making a series of follow-up queries for the users. I had to change the internals of QuizSubmissionImpl a bit so please have a close look in there.