### PR TITLE
AssignmentOverrideReader additional retrieval methods & requisite unit tests.

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/AssignmentOverrideImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentOverrideImpl.java
@@ -26,6 +26,21 @@ public class AssignmentOverrideImpl extends BaseImpl<AssignmentOverride, Assignm
         super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout,
                 paginationPageSize, serializeNulls);
     }
+    
+    @Override
+    public List<AssignmentOverride> listAssignmentOverrides(String courseId, String assignmentId) throws IOException {
+        LOG.debug("Retrieving a list of assignment overrides in course " + courseId + " for assignment " + assignmentId);
+        String url = buildCanvasUrl("courses/" + courseId + "/assignments/" + assignmentId + "/overrides", Collections.emptyMap());
+        return getListFromCanvas(url);
+    }
+
+    @Override
+    public Optional<AssignmentOverride> getAssignmentOverride(String courseId, String assignmentId, String id) throws IOException {
+        LOG.debug("Retrieving an assignment overrides in course " + courseId + " for assignment " + assignmentId);
+        String url = buildCanvasUrl("courses/" + courseId + "/assignments/" + assignmentId + "/overrides/" + id, Collections.emptyMap());
+        Response response = canvasMessenger.getSingleResponseFromCanvas(oauthToken, url);
+        return responseParser.parseToObject(AssignmentOverride.class, response);
+    }
 
     @Override
     public Optional<AssignmentOverride> createAssignmentOverride(String courseId, AssignmentOverride assignmentOverride) throws IOException {

--- a/src/main/java/edu/ksu/canvas/impl/AssignmentOverrideImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentOverrideImpl.java
@@ -28,14 +28,14 @@ public class AssignmentOverrideImpl extends BaseImpl<AssignmentOverride, Assignm
     }
     
     @Override
-    public List<AssignmentOverride> listAssignmentOverrides(String courseId, String assignmentId) throws IOException {
+    public List<AssignmentOverride> listAssignmentOverrides(String courseId, Integer assignmentId) throws IOException {
         LOG.debug("Retrieving a list of assignment overrides in course " + courseId + " for assignment " + assignmentId);
         String url = buildCanvasUrl("courses/" + courseId + "/assignments/" + assignmentId + "/overrides", Collections.emptyMap());
         return getListFromCanvas(url);
     }
 
     @Override
-    public Optional<AssignmentOverride> getAssignmentOverride(String courseId, String assignmentId, String id) throws IOException {
+    public Optional<AssignmentOverride> getAssignmentOverride(String courseId, Integer assignmentId, Integer id) throws IOException {
         LOG.debug("Retrieving an assignment overrides in course " + courseId + " for assignment " + assignmentId);
         String url = buildCanvasUrl("courses/" + courseId + "/assignments/" + assignmentId + "/overrides/" + id, Collections.emptyMap());
         Response response = canvasMessenger.getSingleResponseFromCanvas(oauthToken, url);

--- a/src/main/java/edu/ksu/canvas/interfaces/AssignmentOverrideReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/AssignmentOverrideReader.java
@@ -14,7 +14,7 @@ public interface AssignmentOverrideReader extends CanvasReader<AssignmentOverrid
      * @return
      * @throws IOException 
      */
-    List<AssignmentOverride> listAssignmentOverrides(String courseId, String assignmentId) throws IOException;
+    List<AssignmentOverride> listAssignmentOverrides(String courseId, Integer assignmentId) throws IOException;
     
     /***
      * Returns details of the the override with the given id.
@@ -24,5 +24,5 @@ public interface AssignmentOverrideReader extends CanvasReader<AssignmentOverrid
      * @return
      * @throws IOException 
      */
-    Optional<AssignmentOverride> getAssignmentOverride(String courseId, String assignmentId, String id) throws IOException;
+    Optional<AssignmentOverride> getAssignmentOverride(String courseId, Integer assignmentId, Integer id) throws IOException;
 }

--- a/src/main/java/edu/ksu/canvas/interfaces/AssignmentOverrideReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/AssignmentOverrideReader.java
@@ -1,6 +1,28 @@
 package edu.ksu.canvas.interfaces;
 
 import edu.ksu.canvas.model.assignment.AssignmentOverride;
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
 
 public interface AssignmentOverrideReader extends CanvasReader<AssignmentOverride, AssignmentOverrideReader> {
+    
+    /***
+     * Returns the list of overrides for this assignment that target sections/groups/students visible to the current user.
+     * @param courseId
+     * @param assignmentId
+     * @return
+     * @throws IOException 
+     */
+    List<AssignmentOverride> listAssignmentOverrides(String courseId, String assignmentId) throws IOException;
+    
+    /***
+     * Returns details of the the override with the given id.
+     * @param courseId
+     * @param assignmentId
+     * @param id
+     * @return
+     * @throws IOException 
+     */
+    Optional<AssignmentOverride> getAssignmentOverride(String courseId, String assignmentId, String id) throws IOException;
 }

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentOverrideUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentOverrideUTest.java
@@ -1,0 +1,97 @@
+package edu.ksu.canvas.tests.assignment;
+
+import com.google.gson.JsonSyntaxException;
+import edu.ksu.canvas.CanvasTestBase;
+import static edu.ksu.canvas.CanvasTestBase.DEFAULT_PAGINATION_PAGE_SIZE;
+import static edu.ksu.canvas.CanvasTestBase.SOME_CONNECT_TIMEOUT;
+import static edu.ksu.canvas.CanvasTestBase.SOME_OAUTH_TOKEN;
+import static edu.ksu.canvas.CanvasTestBase.SOME_READ_TIMEOUT;
+import edu.ksu.canvas.impl.AssignmentOverrideImpl;
+import edu.ksu.canvas.interfaces.AssignmentOverrideReader;
+import edu.ksu.canvas.interfaces.AssignmentOverrideWriter;
+import edu.ksu.canvas.model.assignment.AssignmentOverride;
+import edu.ksu.canvas.net.FakeRestClient;
+import edu.ksu.canvas.net.Response;
+
+import org.apache.log4j.Logger;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.Optional;
+
+public class AssignmentOverrideUTest extends CanvasTestBase {
+    private static final Logger LOG = Logger.getLogger(AssignmentRetrieverUTest.class);
+    @Autowired
+    private FakeRestClient fakeRestClient;
+    private AssignmentOverrideReader assignmentOverrideReader;
+    private AssignmentOverrideWriter assignmentOverrideWriter;
+
+    @Before
+    public void setupData() {
+        assignmentOverrideReader = new AssignmentOverrideImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
+        assignmentOverrideWriter = new AssignmentOverrideImpl(baseUrl, apiVersion, SOME_OAUTH_TOKEN, fakeRestClient, SOME_CONNECT_TIMEOUT,
+                SOME_READ_TIMEOUT, DEFAULT_PAGINATION_PAGE_SIZE, false);
+    }
+    
+    @Test(expected = JsonSyntaxException.class)
+    public void testListAssignments_responseInvalid() throws Exception {
+        String someCourseId = "123456";
+        String someAssignmentId = "80";
+        Response erroredResponse = new Response();
+        erroredResponse.setResponseCode(401);
+        String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides";
+        fakeRestClient.addSuccessResponse(url, "InvalidJson.json");
+
+        Assert.assertTrue(assignmentOverrideReader.listAssignmentOverrides(someCourseId, someAssignmentId).isEmpty());
+    }
+    
+    @Test
+    public void testRetrieveAssignmentOverride() throws Exception {
+        AssignmentOverride assignmentOverride1 = new AssignmentOverride();
+        assignmentOverride1.setId(4);
+        String someCourseId = "14";
+        String someAssignmentId = "80";
+        String someAssignmentOverrideId = "4";
+        String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides/" + someAssignmentOverrideId;
+        fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/AssignmentOverride.json");
+        Optional<AssignmentOverride> assignmentOverride = assignmentOverrideReader.getAssignmentOverride(someCourseId, someAssignmentId, someAssignmentOverrideId);
+        Assert.assertTrue(assignmentOverride.isPresent());
+        Assert.assertEquals(new Integer(4), assignmentOverride.map(AssignmentOverride::getId).orElse(0));
+    }
+
+    @Test
+    public void testRetrieveAssignmentOverrides() throws Exception {
+        AssignmentOverride assignmentOverride = new AssignmentOverride();
+        assignmentOverride.setId(4);
+        String someCourseId = "14";
+        String someAssignmentId = "80";
+        String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides";
+        fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/AssignmentOverrideList.json");
+        List<AssignmentOverride> assignmentOverrides = assignmentOverrideReader.listAssignmentOverrides(someCourseId, someAssignmentId);
+        Assert.assertEquals(3, assignmentOverrides.size());
+        Assert.assertTrue(assignmentOverrides.stream().map(AssignmentOverride::getTitle).filter("Sec1"::equals).findFirst().isPresent());
+        Assert.assertTrue(assignmentOverrides.stream().map(AssignmentOverride::getTitle).filter("Sec2"::equals).findFirst().isPresent());
+        Assert.assertTrue(assignmentOverrides.stream().map(AssignmentOverride::getTitle).filter("Sec3"::equals).findFirst().isPresent());
+    }
+    
+    @Test
+    public void testCreateAssignmentOverride() throws Exception {
+        String someCourseId = "14";
+        Integer someAssignmentId = 80;
+        AssignmentOverride assignmentOverride1 = new AssignmentOverride();
+        assignmentOverride1.setId(4);
+        assignmentOverride1.setTitle("Section1");
+        assignmentOverride1.setAssignmentId(someAssignmentId);
+        String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides";
+        fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/AssignmentOverride.json");
+        Optional<AssignmentOverride> assignmentOverride = assignmentOverrideWriter.createAssignmentOverride(someCourseId, assignmentOverride1);
+        System.out.println(assignmentOverride.toString());
+        Assert.assertTrue(assignmentOverride.isPresent());
+        Assert.assertNotNull(assignmentOverride.get().getId());
+        Assert.assertEquals("Sec3", assignmentOverride.get().getTitle());
+    }
+}

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentOverrideUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentOverrideUTest.java
@@ -40,7 +40,7 @@ public class AssignmentOverrideUTest extends CanvasTestBase {
     @Test(expected = JsonSyntaxException.class)
     public void testListAssignments_responseInvalid() throws Exception {
         String someCourseId = "14";
-        String someAssignmentId = "80";
+        Integer someAssignmentId = 80;
         Response erroredResponse = new Response();
         erroredResponse.setResponseCode(401);
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides";
@@ -54,8 +54,8 @@ public class AssignmentOverrideUTest extends CanvasTestBase {
         AssignmentOverride assignmentOverride1 = new AssignmentOverride();
         assignmentOverride1.setId(4);
         String someCourseId = "14";
-        String someAssignmentId = "80";
-        String someAssignmentOverrideId = "4";
+        Integer someAssignmentId = 80;
+        Integer someAssignmentOverrideId = 4;
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides/" + someAssignmentOverrideId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/AssignmentOverride.json");
         Optional<AssignmentOverride> assignmentOverride = assignmentOverrideReader.getAssignmentOverride(someCourseId, someAssignmentId, someAssignmentOverrideId);
@@ -69,7 +69,7 @@ public class AssignmentOverrideUTest extends CanvasTestBase {
         AssignmentOverride assignmentOverride = new AssignmentOverride();
         assignmentOverride.setId(4);
         String someCourseId = "14";
-        String someAssignmentId = "80";
+        Integer someAssignmentId = 80;
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides";
         fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/AssignmentOverrideList.json");
         List<AssignmentOverride> assignmentOverrides = assignmentOverrideReader.listAssignmentOverrides(someCourseId, someAssignmentId);

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentOverrideUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentOverrideUTest.java
@@ -39,7 +39,7 @@ public class AssignmentOverrideUTest extends CanvasTestBase {
     
     @Test(expected = JsonSyntaxException.class)
     public void testListAssignments_responseInvalid() throws Exception {
-        String someCourseId = "123456";
+        String someCourseId = "14";
         String someAssignmentId = "80";
         Response erroredResponse = new Response();
         erroredResponse.setResponseCode(401);
@@ -59,6 +59,7 @@ public class AssignmentOverrideUTest extends CanvasTestBase {
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides/" + someAssignmentOverrideId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/AssignmentOverride.json");
         Optional<AssignmentOverride> assignmentOverride = assignmentOverrideReader.getAssignmentOverride(someCourseId, someAssignmentId, someAssignmentOverrideId);
+        
         Assert.assertTrue(assignmentOverride.isPresent());
         Assert.assertEquals(new Integer(4), assignmentOverride.map(AssignmentOverride::getId).orElse(0));
     }
@@ -72,6 +73,7 @@ public class AssignmentOverrideUTest extends CanvasTestBase {
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides";
         fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/AssignmentOverrideList.json");
         List<AssignmentOverride> assignmentOverrides = assignmentOverrideReader.listAssignmentOverrides(someCourseId, someAssignmentId);
+        
         Assert.assertEquals(3, assignmentOverrides.size());
         Assert.assertTrue(assignmentOverrides.stream().map(AssignmentOverride::getTitle).filter("Sec1"::equals).findFirst().isPresent());
         Assert.assertTrue(assignmentOverrides.stream().map(AssignmentOverride::getTitle).filter("Sec2"::equals).findFirst().isPresent());
@@ -89,6 +91,7 @@ public class AssignmentOverrideUTest extends CanvasTestBase {
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "/overrides";
         fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/AssignmentOverride.json");
         Optional<AssignmentOverride> assignmentOverride = assignmentOverrideWriter.createAssignmentOverride(someCourseId, assignmentOverride1);
+        
         System.out.println(assignmentOverride.toString());
         Assert.assertTrue(assignmentOverride.isPresent());
         Assert.assertNotNull(assignmentOverride.get().getId());

--- a/src/test/resources/SampleJson/assignment/AssignmentOverride.json
+++ b/src/test/resources/SampleJson/assignment/AssignmentOverride.json
@@ -1,0 +1,11 @@
+{
+  "id": 4,
+  "assignment_id": 80,
+  "title": "Sec3",
+  "due_at": null,
+  "all_day": false,
+  "all_day_date": null,
+  "unlock_at": null,
+  "lock_at": null,
+  "course_section_id": 38
+}

--- a/src/test/resources/SampleJson/assignment/AssignmentOverrideList.json
+++ b/src/test/resources/SampleJson/assignment/AssignmentOverrideList.json
@@ -19,7 +19,7 @@
         "all_day_date": null,
         "unlock_at": null,
         "lock_at": null,
-        "course_section_id": 38
+        "course_section_id": 39
     },
     {
         "id": 6,
@@ -30,6 +30,6 @@
         "all_day_date": null,
         "unlock_at": null,
         "lock_at": null,
-        "course_section_id": 38
+        "course_section_id": 40
     }
 ]

--- a/src/test/resources/SampleJson/assignment/AssignmentOverrideList.json
+++ b/src/test/resources/SampleJson/assignment/AssignmentOverrideList.json
@@ -1,0 +1,35 @@
+[
+    {
+        "id": 4,
+        "assignment_id": 80,
+        "title": "Sec1",
+        "due_at": null,
+        "all_day": false,
+        "all_day_date": null,
+        "unlock_at": null,
+        "lock_at": null,
+        "course_section_id": 38
+    },
+    {
+        "id": 5,
+        "assignment_id": 81,
+        "title": "Sec2",
+        "due_at": null,
+        "all_day": false,
+        "all_day_date": null,
+        "unlock_at": null,
+        "lock_at": null,
+        "course_section_id": 38
+    },
+    {
+        "id": 6,
+        "assignment_id": 82,
+        "title": "Sec3",
+        "due_at": null,
+        "all_day": false,
+        "all_day_date": null,
+        "unlock_at": null,
+        "lock_at": null,
+        "course_section_id": 38
+    }
+]


### PR DESCRIPTION
I've expanded the AssignmentOverrideReader interface & implementation to support the following Canvas API endpoints:

- GET /v1/courses/{course_id}/assignments/{assignment_id}/overrides
- GET /v1/courses/{course_id}/assignments/{assignment_id}/overrides/{id}

I've also included an AssignmentOverride oriented Unit Test class in the assignments package, along with JSON test data. This includes the addition of a test case for the existing & unmodified AssignmentOverrideWriter class as well.

These commits were helpful for a project I'm working on, and it is my hope that they will be useful for the wider community as well.