### PR TITLE
Fix for build encoding warning.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,9 @@
     <name>Kansas State University, Office of Mediated Education</name>
     <url>http://ome.ksu.edu/</url>
   </organization>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
   <developers>
     <developer>


### PR DESCRIPTION
In the logs you get a warning that the build is platform dependent:

[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!

This fixes it by specifying that the source files are UTF-8