### PR TITLE
Fixed update user call

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/AssignmentGroupImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentGroupImpl.java
@@ -62,7 +62,7 @@ public class AssignmentGroupImpl extends BaseImpl<AssignmentGroup, AssignmentGro
         }
         LOG.debug("Creating new assignment group in course " + courseId + ", group name: " + assignmentGroup.getName());
         String url = buildCanvasUrl("courses/" + courseId + "/assignment_groups", Collections.emptyMap());
-        Response response = canvasMessenger.sendToCanvas(oauthToken, url, assignmentGroup.toPostMap());
+        Response response = canvasMessenger.sendToCanvas(oauthToken, url, assignmentGroup.toPostMap(serializeNulls));
         return responseParser.parseToObject(AssignmentGroup.class, response);
     }
 
@@ -73,7 +73,7 @@ public class AssignmentGroupImpl extends BaseImpl<AssignmentGroup, AssignmentGro
         }
         LOG.debug("Modifying assignment group " + assignmentGroup.getId() + " in course " + courseId);
         String url = buildCanvasUrl("courses/" + courseId + "/assignment_groups/" + assignmentGroup.getId(), Collections.emptyMap());
-        Response response = canvasMessenger.putToCanvas(oauthToken, url, assignmentGroup.toPostMap());
+        Response response = canvasMessenger.putToCanvas(oauthToken, url, assignmentGroup.toPostMap(serializeNulls));
         return responseParser.parseToObject(AssignmentGroup.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
@@ -107,7 +107,7 @@ public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, Enrol
             createdUrl = buildCanvasUrl("courses/" + enrollment.getCourseId() + "/enrollments", Collections.emptyMap());
         }
         LOG.debug("create URl for course enrollments: "+ createdUrl);
-        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, enrollment.toPostMap());
+        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, enrollment.toPostMap(serializeNulls));
         if (response.getErrorHappened() ||  response.getResponseCode() != 200) {
             LOG.error("Failed to enroll in course, error message: " + response.toString());
             return Optional.empty();

--- a/src/main/java/edu/ksu/canvas/impl/UserImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/UserImpl.java
@@ -35,7 +35,7 @@ public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements 
     public Optional<User> createUser(User user) throws InvalidOauthTokenException, IOException {
         String createdUrl = buildCanvasUrl( "accounts/" + CanvasConstants.ACCOUNT_ID + "/users", Collections.emptyMap());
         LOG.debug("create URl for user creation : "+ createdUrl);
-        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, user.toPostMap());
+        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, user.toPostMap(serializeNulls));
         if (response.getErrorHappened() || ( response.getResponseCode() != 200)) {
             LOG.debug("Failed to create user, error message: " + response.toString());
             return Optional.empty();
@@ -50,7 +50,12 @@ public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements 
         }
         LOG.debug("updating user in Canvas: " + user.getId());
         String url = buildCanvasUrl("users/" + String.valueOf(user.getId()), Collections.emptyMap());
-        Response response = canvasMessenger.putToCanvas(oauthToken, url, user.toPostMap());
+
+        //I tried to use the JSON POST method but Canvas throws odd permission errors when trying to serialize the user
+        //object, even for an admin user. I suspect some field within the User object can't be updated and instead of
+        //ignoring it like most calls, the user call throws a permission error. So I had to fall back to sending a form POST
+        //since it only serializes fields with a @CanvasField annotation
+        Response response = canvasMessenger.putToCanvas(oauthToken, url, user.toPostMap(serializeNulls));
         return responseParser.parseToObject(User.class, response);
     }
 

--- a/src/main/java/edu/ksu/canvas/impl/UserImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/UserImpl.java
@@ -45,17 +45,13 @@ public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements 
 
     @Override
     public Optional<User> updateUser(User user) throws InvalidOauthTokenException, IOException {
-        Map<String, List<String>> postParameters = new HashMap<>();
-        postParameters.put("name", Collections.singletonList(user.getName()));
-        postParameters.put("pseudonym[unique_id]", Collections.singletonList(user.getLoginId()));
-        String createdUrl = buildCanvasUrl("accounts/" + String.valueOf(user.getId()) + "/users", Collections.emptyMap());
-        LOG.debug("create URl for user creation : " + createdUrl);
-        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, postParameters);
-        if (response.getErrorHappened() || ( response.getResponseCode() != 200)) {
-            LOG.debug("Failed to create user, error message: " + response.toString());
-            return Optional.empty();
+        if(user == null || user.getId() == 0) {
+            throw new IllegalArgumentException("User to update must not be null and have a Canvas ID assigned");
         }
-        return responseParser.parseToObject(User.class,response);
+        LOG.debug("updating user in Canvas: " + user.getId());
+        String url = buildCanvasUrl("users/" + String.valueOf(user.getId()), Collections.emptyMap());
+        Response response = canvasMessenger.putToCanvas(oauthToken, url, user.toPostMap());
+        return responseParser.parseToObject(User.class, response);
     }
 
     @Override

--- a/src/main/java/edu/ksu/canvas/model/BaseCanvasModel.java
+++ b/src/main/java/edu/ksu/canvas/model/BaseCanvasModel.java
@@ -8,6 +8,7 @@ import org.apache.log4j.Logger;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -22,7 +23,7 @@ public abstract class BaseCanvasModel {
      * they are just 'field'. This method will create a map with the correct post keys and values based on the
      * @CanvasField and @CanvasObject annotations.
      */
-    public Map<String, List<String>> toPostMap() {
+    public Map<String, List<String>> toPostMap(boolean includeNulls) {
         Class<? extends BaseCanvasModel> clazz = this.getClass();
         Map<String, List<String>> postMap = new HashMap<>();
         for (Method method : clazz.getMethods()) {
@@ -31,7 +32,7 @@ public abstract class BaseCanvasModel {
                 final String postKey = getPostKey(canvasFieldAnnotation);
                 try {
                     final List<String> fieldValues = getFieldValues(method);
-                    if (fieldValues != null) {
+                    if ((fieldValues != null && !fieldValues.isEmpty()) || includeNulls) {
                         if (postMap.containsKey(postKey)) {
                             postMap.get(postKey).addAll(fieldValues);
                         } else {
@@ -94,7 +95,7 @@ public abstract class BaseCanvasModel {
         final Object returnValue = getter.invoke(this);
 
         if (returnValue == null) {
-           return null;
+           return Collections.emptyList();
         }
 
         if (Iterable.class.isAssignableFrom(returnType)) {

--- a/src/main/java/edu/ksu/canvas/model/User.java
+++ b/src/main/java/edu/ksu/canvas/model/User.java
@@ -127,6 +127,7 @@ public class User extends BaseCanvasModel implements Serializable {
         this.enrollments = enrollments;
     }
 
+    @CanvasField(postKey = "locale")
     public String getLocale() {
         return locale;
     }

--- a/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
@@ -302,9 +302,13 @@ public class SimpleRestClient implements RestClient {
 
         for (final Map.Entry<String, List<String>> param : parameterMap.entrySet()) {
             final String key = param.getKey();
+            if(param.getValue() == null || param.getValue().isEmpty()) {
+                params.add(new BasicNameValuePair(key, null));
+                LOG.debug("key: " + key + "\tempty value");
+            }
             for (final String value : param.getValue()) {
                 params.add(new BasicNameValuePair(key, value));
-                LOG.debug("key "+ key +"\t value : " + value);
+                LOG.debug("key: "+ key +"\tvalue: " + value);
             }
         }
         return params;

--- a/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
+++ b/src/test/java/edu/ksu/canvas/BaseCanvasModelUTest.java
@@ -33,7 +33,7 @@ public class BaseCanvasModelUTest {
         TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField1(FIELD1_VALUE);
 
-        Map<String, List<String>> postMap = canvasModel.toPostMap();
+        Map<String, List<String>> postMap = canvasModel.toPostMap(false);
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field1", postMap.containsKey(expectedKey));
         Assert.assertArrayEquals("Field1Value from canvasModel.toPostMap() did not have expected value for field1", new String[] { FIELD1_VALUE }, postMap.get(expectedKey).toArray());
@@ -46,7 +46,7 @@ public class BaseCanvasModelUTest {
         TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField2(FIELD2_VALUE);
 
-        Map<String, List<String>> postMap = canvasModel.toPostMap();
+        Map<String, List<String>> postMap = canvasModel.toPostMap(false);
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field2", postMap.containsKey(expectedKey));
         Assert.assertArrayEquals("Field2Value from canvasModel.toPostMap() did not have expected value for field2", new String[] { FIELD2_VALUE }, postMap.get(expectedKey).toArray());
@@ -59,7 +59,7 @@ public class BaseCanvasModelUTest {
         final TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField3(FIELD3_VALUE);
 
-        final Map<String, List<String>> postMap = canvasModel.toPostMap();
+        final Map<String, List<String>> postMap = canvasModel.toPostMap(false);
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field3", postMap.containsKey(expectedKey));
         Assert.assertArrayEquals("Field3Value from canvasModel.toPostMap() did not have expected value for field3", new String[] { FIELD3_VALUE }, postMap.get(expectedKey).toArray());
@@ -71,7 +71,7 @@ public class BaseCanvasModelUTest {
         final TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField4(FIELD4_VALUE);
 
-        final Map<String, List<String>> postMap = canvasModel.toPostMap();
+        final Map<String, List<String>> postMap = canvasModel.toPostMap(false);
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field4", postMap.containsKey(expectedKey));
         Assert.assertArrayEquals("Field3Value from canvasModel.toPostMap() did not have expected value for field4", new String[] { String.valueOf(FIELD4_VALUE) }, postMap.get(expectedKey).toArray());
@@ -83,7 +83,7 @@ public class BaseCanvasModelUTest {
         final TestCanvasModel canvasModel = new TestCanvasModel();
         canvasModel.setField5(FIELD5_VALUE);
 
-        final Map<String, List<String>> postMap = canvasModel.toPostMap();
+        final Map<String, List<String>> postMap = canvasModel.toPostMap(false);
         final String[] expectedValue = FIELD5_VALUE.stream().map(String::valueOf).collect(Collectors.toList()).toArray(new String[] {});
 
         Assert.assertTrue("PostKey from canvasModel.toPostMap() did not have expected key for field5", postMap.containsKey(expectedKey));
@@ -93,7 +93,7 @@ public class BaseCanvasModelUTest {
     @Test
     public void postKeysAsArraysContainsNoNullValues() throws Exception {
         final TestCanvasModel canvasModel = new TestCanvasModel();
-        final Map<String, List<String>> postMap = canvasModel.toPostMap();
+        final Map<String, List<String>> postMap = canvasModel.toPostMap(false);
         Assert.assertTrue("Result of canvasModel.toPostMap() is not empty as expected", postMap.isEmpty());
     }
 


### PR DESCRIPTION
The update user call was only setting a handful of fields and basically didn't work at all. This makes it work again and also implements the `serializeNulls` behavior for calls that use the form post method of communicating with Canvas instead of the JSON post.