### PR TITLE
Changed Assignment ID to be an integer instead of a String

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/AssignmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentImpl.java
@@ -61,7 +61,7 @@ public class AssignmentImpl extends BaseImpl<Assignment, AssignmentReader, Assig
     }
 
     @Override
-    public Optional<Assignment> deleteAssignment(String courseId, String assignmentId) throws IOException {
+    public Optional<Assignment> deleteAssignment(String courseId, Integer assignmentId) throws IOException {
         Map<String, List<String>> postParams = new HashMap<>();
         postParams.put("event", Collections.singletonList("delete"));
         String createdUrl = buildCanvasUrl("courses/" + courseId + "/assignments/" + assignmentId, Collections.emptyMap());

--- a/src/main/java/edu/ksu/canvas/interfaces/AssignmentWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/AssignmentWriter.java
@@ -23,7 +23,7 @@ public interface AssignmentWriter extends CanvasWriter<Assignment, AssignmentWri
      * @return The deleted Assignment object as returned by the Canvas API
      * @throws IOException When there is an error communicating with Canvas
      */
-    Optional<Assignment> deleteAssignment(String courseId, String assignmentId) throws IOException;
+    Optional<Assignment> deleteAssignment(String courseId, Integer assignmentId) throws IOException;
 
     /**
      * Writes an Assignment object to the Canvas API

--- a/src/main/java/edu/ksu/canvas/model/assignment/Assignment.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/Assignment.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class Assignment extends BaseCanvasModel implements Serializable{
 
     private static final long serialVersionUID = 1L;
-    private String id;
+    private Integer id;
     private String name;
     private String description;
     private Date createdAt;
@@ -58,11 +58,11 @@ public class Assignment extends BaseCanvasModel implements Serializable{
     private Boolean notifyOfUpdate;
 
 
-    public String getId() {
+    public Integer getId() {
         return id;
     }
 
-    public void setId(String id) {
+    public void setId(Integer id) {
         this.id = id;
     }
 

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSingleAssignmentOptions.java
@@ -5,7 +5,7 @@ import java.util.List;
 public class GetSingleAssignmentOptions extends BaseOptions {
     
     private String courseId;
-    private String assignmentId;
+    private Integer assignmentId;
 
     public enum Include {
         SUBMISSION, ASSIGNMENT_VISIBILITY, OVERRIDES, OBSERVED_USERS;
@@ -16,7 +16,10 @@ public class GetSingleAssignmentOptions extends BaseOptions {
         }
     }
 
-    public GetSingleAssignmentOptions(String courseId, String assignmentId) {
+    public GetSingleAssignmentOptions(String courseId, Integer assignmentId) {
+        if(courseId == null || assignmentId == null) {
+            throw new IllegalArgumentException("Course and assignment IDs are required");
+        }
         this.courseId = courseId;
         this.assignmentId = assignmentId;
     }
@@ -25,7 +28,7 @@ public class GetSingleAssignmentOptions extends BaseOptions {
         return courseId;
     }
 
-    public String getAssignmentId() {
+    public Integer getAssignmentId() {
         return assignmentId;
     }
 

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentRetrieverUTest.java
@@ -37,9 +37,9 @@ public class AssignmentRetrieverUTest extends CanvasTestBase {
     public void testListCourseAssignments() throws Exception {
         String someCourseId = "123456";
         Assignment assignment1 = new Assignment();
-        assignment1.setId("1");
+        assignment1.setId(1);
         Assignment assignment2 = new Assignment();
-        assignment2.setId("2");
+        assignment2.setId(2);
         Response notErroredResponse = new Response();
         notErroredResponse.setErrorHappened(false);
         notErroredResponse.setResponseCode(200);
@@ -66,7 +66,7 @@ public class AssignmentRetrieverUTest extends CanvasTestBase {
     @Test
     public void testRetrieveAssignment() throws Exception {
         String someCourseId = "1234";
-        String someAssignmentId = "123";
+        Integer someAssignmentId = 123;
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/MinimalAssignment.json");
         Optional<Assignment> assignment = assignmentReader.getSingleAssignment(new GetSingleAssignmentOptions(someCourseId, someAssignmentId));
@@ -79,9 +79,9 @@ public class AssignmentRetrieverUTest extends CanvasTestBase {
         String someUserId = "899123456";
         String someCourseId = "123456";
         Assignment assignment1 = new Assignment();
-        assignment1.setId("1");
+        assignment1.setId(1);
         Assignment assignment2 = new Assignment();
-        assignment2.setId("2");
+        assignment2.setId(2);
         Response notErroredResponse = new Response();
         notErroredResponse.setErrorHappened(false);
         notErroredResponse.setResponseCode(200);
@@ -109,7 +109,7 @@ public class AssignmentRetrieverUTest extends CanvasTestBase {
     public void testSisUserMasqueradingRetriveAssignment() throws Exception{
         String someUserId = "8991123123";
         String someCourseId = "1234";
-        String someAssignmentId = "123";
+        Integer someAssignmentId = 123;
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "?as_user_id=" + CanvasConstants.MASQUERADE_SIS_USER + ":" + someUserId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/MinimalAssignment.json");
         Optional<Assignment> assignment = assignmentReader.readAsSisUser(someUserId).getSingleAssignment(new GetSingleAssignmentOptions(someCourseId, someAssignmentId));
@@ -122,9 +122,9 @@ public class AssignmentRetrieverUTest extends CanvasTestBase {
         String someUserId = "899123456";
         String someCourseId = "123456";
         Assignment assignment1 = new Assignment();
-        assignment1.setId("1");
+        assignment1.setId(1);
         Assignment assignment2 = new Assignment();
-        assignment2.setId("2");
+        assignment2.setId(2);
         Response notErroredResponse = new Response();
         notErroredResponse.setErrorHappened(false);
         notErroredResponse.setResponseCode(200);
@@ -152,7 +152,7 @@ public class AssignmentRetrieverUTest extends CanvasTestBase {
     public void testCanvasUserMasqueradingRetriveAssignment() throws Exception{
         String someUserId = "8991123123";
         String someCourseId = "1234";
-        String someAssignmentId = "123";
+        Integer someAssignmentId = 123;
         String url = baseUrl + "/api/v1/courses/" + someCourseId + "/assignments/" + someAssignmentId + "?as_user_id=" + someUserId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/assignment/MinimalAssignment.json");
         Optional<Assignment> assignment = assignmentReader.readAsCanvasUser(someUserId).getSingleAssignment(new GetSingleAssignmentOptions(someCourseId, someAssignmentId));


### PR DESCRIPTION
String IDs have to be used if an SIS ID can be used to query an object
but this is not possible with assignments so there is no reason to have
it be anything other than an Integer.