### PR TITLE
Add override grade properties.

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/Grade.java
+++ b/src/main/java/edu/ksu/canvas/model/Grade.java
@@ -18,6 +18,8 @@ public class Grade implements Serializable {
     private String finalGrade;
     private String unpostedCurrentGrade;
     private String unpostedFinalGrade;
+    private String overrideGrade;
+    private String overrideScore;
 
     public String getHtmlUrl() {
         return htmlUrl;
@@ -59,6 +61,14 @@ public class Grade implements Serializable {
         this.unpostedFinalScore = unpostedFinalScore;
     }
 
+    public String getOverrideScore() {
+        return overrideScore;
+    }
+
+    public void setOverrideScore(String overrideScore) {
+        this.overrideScore = overrideScore;
+    }
+
     public String getCurrentGrade() {
         return currentGrade;
     }
@@ -89,5 +99,13 @@ public class Grade implements Serializable {
 
     public void setUnpostedFinalGrade(String unpostedFinalGrade) {
         this.unpostedFinalGrade = unpostedFinalGrade;
+    }
+
+    public String getOverrideGrade() {
+        return overrideGrade;
+    }
+
+    public void setOverrideGrade(String overrideGrade) {
+        this.overrideGrade = overrideGrade;
     }
 }

--- a/src/test/java/edu/ksu/canvas/EnrollmentUTest.java
+++ b/src/test/java/edu/ksu/canvas/EnrollmentUTest.java
@@ -75,6 +75,8 @@ public class EnrollmentUTest extends CanvasTestBase {
         Assert.assertEquals("Expected finalScore to match finalScore in json", "30.24", grade.getFinalScore());
         Assert.assertEquals("Expected currentGrade to match currentGrade in json", "F", grade.getCurrentGrade());
         Assert.assertEquals("Expected finalGrade to match finalGrade in json", "A", grade.getFinalGrade());
+        Assert.assertEquals("Expected overrideGrade to match overrideGrade in json", "B", grade.getOverrideGrade());
+        Assert.assertEquals("Expected overrideScore to match overrideScore in json", "83", grade.getOverrideScore());
     }
 
     @Test

--- a/src/test/resources/SampleJson/Enrollments.json
+++ b/src/test/resources/SampleJson/Enrollments.json
@@ -29,7 +29,9 @@
       "current_score": 45,
       "final_score": 30.24,
       "current_grade": "F",
-      "final_grade": "A"
+      "final_grade": "A",
+      "override_grade": "B",
+      "override_score": 83
     },
     "user": {
       "id": 38,


### PR DESCRIPTION
These are new Canvas API fields that allow the instructor to set a grade that should take precedence over any of the other grade fields in the enrollments API.