### PR TITLE
log4j is required to use this library.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -243,7 +243,6 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.16</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
If a consumer of this project doesn’t need log4j then they should mark it as provided in their dependencies.

Fixes #103