### PR TITLE
Remove duplicate call to checkHeaders.

### DIFF
--- a/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
@@ -60,7 +60,6 @@ public class SimpleRestClient implements RestClient {
             httpGet.setHeader("Authorization", "Bearer" + " " + token.getAccessToken());
 
             try (CloseableHttpResponse httpResponse = httpClient.execute(httpGet)) {
-                checkHeaders(httpResponse, httpGet);
 
                 //deal with the actual content
                 response.setContent(handleResponse(httpResponse, httpGet));


### PR DESCRIPTION
handleResponse() that is called on the next line also starts out by calling checkHeaders to this call directly inside sendApiGet() is redundant.