### PR TITLE
This adds the ability to extract better errors.

### DIFF
--- a/src/main/java/edu/ksu/canvas/errors/ErrorHandler.java
+++ b/src/main/java/edu/ksu/canvas/errors/ErrorHandler.java
@@ -1,0 +1,14 @@
+package edu.ksu.canvas.errors;
+
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+
+/**
+ * This allows additional specific behaviour for handling errors.
+ */
+public interface ErrorHandler {
+
+    boolean shouldHandle(HttpRequest httpRequest, HttpResponse httpResponse);
+
+    void handle(HttpRequest httpRequest, HttpResponse httpResponse);
+}

--- a/src/main/java/edu/ksu/canvas/errors/UserErrorHandler.java
+++ b/src/main/java/edu/ksu/canvas/errors/UserErrorHandler.java
@@ -1,0 +1,41 @@
+package edu.ksu.canvas.errors;
+
+import com.google.gson.Gson;
+import edu.ksu.canvas.exception.CanvasException;
+import edu.ksu.canvas.impl.GsonResponseParser;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * The error handler that should be used when creation of a user fails.
+ */
+public class UserErrorHandler implements ErrorHandler {
+
+    private Pattern pattern = Pattern.compile("/api/v1/accounts/\\d+/users");
+
+    @Override
+    public boolean shouldHandle(HttpRequest httpRequest, HttpResponse httpResponse) {
+        return
+                pattern.matcher(httpRequest.getRequestLine().getUri()).find() &&
+                httpResponse.getStatusLine().getStatusCode() == 400 &&
+                httpResponse.getEntity().getContentType().getValue().contains("application/json");
+    }
+
+    @Override
+    public void handle(HttpRequest httpRequest, HttpResponse httpResponse) {
+        Gson gson = GsonResponseParser.getDefaultGsonParser(false);
+        try {
+            UserErrorResponse response = gson.fromJson(EntityUtils.toString(httpResponse.getEntity()), UserErrorResponse.class);
+            if (response.getErrors() != null) {
+                throw new CanvasException("Failed to create user.", httpRequest.getRequestLine().getUri(), response);
+            }
+        } catch (IOException e) {
+            // Ignore.
+        }
+
+    }
+}

--- a/src/main/java/edu/ksu/canvas/errors/UserErrorResponse.java
+++ b/src/main/java/edu/ksu/canvas/errors/UserErrorResponse.java
@@ -1,0 +1,95 @@
+package edu.ksu.canvas.errors;
+
+import java.util.List;
+
+/**
+ * The error object that is returned when the creation of a user fails because the data isn't good.
+ * This allows you to retrieve more information about what was wrong with your request.
+ */
+public class UserErrorResponse {
+
+    private Errors errors;
+
+    public Errors getErrors() {
+        return errors;
+    }
+
+    public void setErrors(Errors errors) {
+        this.errors = errors;
+    }
+
+    public static class Errors {
+        private User user;
+        private Pseudonym pseudonym;
+
+        public User getUser() {
+            return user;
+        }
+
+        public void setUser(User user) {
+            this.user = user;
+        }
+
+        public Pseudonym getPseudonym() {
+            return pseudonym;
+        }
+
+        public void setPseudonym(Pseudonym pseudonym) {
+            this.pseudonym = pseudonym;
+        }
+
+        public static class User {
+            private List<Error> pseudonyms;
+
+            public List<Error> getPseudonyms() {
+                return pseudonyms;
+            }
+
+            public void setPseudonyms(List<Error> pseudonyms) {
+                this.pseudonyms = pseudonyms;
+            }
+        }
+
+        public static class Pseudonym {
+            private List<Error> uniqueId;
+
+            public List<Error> getUniqueId() {
+                return uniqueId;
+            }
+
+            public void setUniqueId(List<Error> uniqueId) {
+                this.uniqueId = uniqueId;
+            }
+        }
+
+        public static class Error {
+            private String attribute;
+            private String type;
+            private String message;
+
+            public String getAttribute() {
+                return attribute;
+            }
+
+            public void setAttribute(String attribute) {
+                this.attribute = attribute;
+            }
+
+            public String getType() {
+                return type;
+            }
+
+            public void setType(String type) {
+                this.type = type;
+            }
+
+            public String getMessage() {
+                return message;
+            }
+
+            public void setMessage(String message) {
+                this.message = message;
+            }
+        }
+    }
+}

--- a/src/main/java/edu/ksu/canvas/exception/CanvasException.java
+++ b/src/main/java/edu/ksu/canvas/exception/CanvasException.java
@@ -12,16 +12,29 @@ public class CanvasException extends RuntimeException {
 
     private final String canvasErrorMessage;
     private final String requestUrl;
+    private final Object error;
 
     public CanvasException() {
         canvasErrorMessage = null;
         requestUrl = null;
+        error = null;
     }
 
     public CanvasException(String canvasErrorString, String url) {
         super(String.format("Error from URL %s : %s", url, canvasErrorString));
         canvasErrorMessage = canvasErrorString;
         requestUrl = url;
+        error = null;
+    }
+
+    public CanvasException(String canvasErrorString, String url, Object error) {
+        canvasErrorMessage = canvasErrorString;
+        requestUrl = url;
+        this.error = error;
+    }
+
+    public Object getError() {
+        return error;
     }
 
     public String getCanvasErrorMessage() {

--- a/src/test/java/edu/ksu/canvas/errors/ErrorsJsonTest.java
+++ b/src/test/java/edu/ksu/canvas/errors/ErrorsJsonTest.java
@@ -1,0 +1,27 @@
+package edu.ksu.canvas.errors;
+
+import com.google.gson.Gson;
+import edu.ksu.canvas.impl.GsonResponseParser;
+import org.junit.Test;
+
+import java.io.InputStreamReader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ErrorsJsonTest {
+
+
+    @Test
+    public void testFailedDuplicateId() {
+        InputStreamReader reader = new InputStreamReader(getClass().getResourceAsStream("/SampleJson/user/UserCreateFailedDuplicateId.json"));
+        Gson gson = GsonResponseParser.getDefaultGsonParser(false);
+        UserErrorResponse response = gson.fromJson(reader, UserErrorResponse.class);
+        assertNotNull(response);
+        assertNotNull(response.getErrors());
+        assertNotNull(response.getErrors().getUser());
+        assertNotNull(response.getErrors().getUser().getPseudonyms());
+        assertEquals(1, response.getErrors().getUser().getPseudonyms().size());
+        assertEquals("pseudonyms", response.getErrors().getUser().getPseudonyms().get(0).getAttribute());
+    }
+}

--- a/src/test/java/edu/ksu/canvas/net/SimpleRestClientUTest.java
+++ b/src/test/java/edu/ksu/canvas/net/SimpleRestClientUTest.java
@@ -1,6 +1,7 @@
 package edu.ksu.canvas.net;
 
 import edu.ksu.canvas.LocalServerTestBase;
+import edu.ksu.canvas.errors.UserErrorResponse;
 import edu.ksu.canvas.exception.CanvasException;
 import edu.ksu.canvas.exception.InvalidOauthTokenException;
 import edu.ksu.canvas.exception.UnauthorizedException;
@@ -17,8 +18,9 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-
+import static org.junit.Assert.assertTrue;
 
 
 @RunWith(JUnit4.class)
@@ -95,4 +97,32 @@ public class SimpleRestClientUTest extends LocalServerTestBase {
         restClient.sendApiGet(emptyAdminToken, baseUrl + url, 100, 100);
     }
 
+    @Test
+    public void userCreationError() throws Exception {
+        // This test can't easily be in the user part as we need too much control over the response
+        String url = "/api/v1/accounts/1/users";
+        registerUrlResponse(url, "/SampleJson/user/UserCreateFailedDuplicateId.json", 400, Collections.singletonMap("Content-Type", "application/json"));
+        try {
+            restClient.sendApiPost(emptyAdminToken, baseUrl + url, Collections.emptyMap(), 100, 100);
+        } catch (CanvasException e) {
+            Object o = e.getError();
+            assertNotNull(o);
+            // Validate that we did correctly parse the response
+            assertTrue(o instanceof UserErrorResponse);
+        }
+    }
+
+    @Test
+    public void userCreationErrorNormalError() throws Exception {
+        // This test can't easily be in the user part as we need too much control over the response
+        String url = "/api/v1/accounts/1/users";
+        registerUrlResponse(url, "/SampleJson/sampleErrorMessageWithoutErrorArray.json", 400, Collections.singletonMap("Content-Type", "application/json"));
+        try {
+            restClient.sendApiPost(emptyAdminToken, baseUrl + url, Collections.emptyMap(), 100, 100);
+        } catch (CanvasException e) {
+            Object o = e.getError();
+            // We shouldn't have helpful error object as this is a generic error.
+            assertNull(o);
+        }
+    }
 }

--- a/src/test/resources/SampleJson/user/UserCreateFailedDuplicateId.json
+++ b/src/test/resources/SampleJson/user/UserCreateFailedDuplicateId.json
@@ -1,0 +1,24 @@
+{
+  "errors": {
+    "user": {
+      "pseudonyms": [
+        {
+          "attribute": "pseudonyms",
+          "type": "invalid",
+          "message": "invalid"
+        }
+      ]
+    },
+    "pseudonym": {
+      "unique_id": [
+        {
+          "attribute": "unique_id",
+          "type": "taken",
+          "message": "ID already in use for this account and authentication provider"
+        }
+      ]
+    },
+    "observee": {},
+    "pairing_code": {}
+  }
+}


### PR DESCRIPTION
When creating a user an error JSON is returned that includes messages about what went wrong. These messages are useful for displaying to the user or handling in code. Rather than putting logic about the /api/v1/users endpoint in the SimpleRestClient I’ve created ErrorHandlers that can say they want to handle the error instead of the standard code. This way the user error handling code is kept self contained.

Sadly there’s no documentation on these error objects short of reading the upstream code.