### PR TITLE
Support options when creating a user.

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/UserImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/UserImpl.java
@@ -9,6 +9,7 @@ import edu.ksu.canvas.model.User;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
+import edu.ksu.canvas.requestOptions.CreateUserOptions;
 import edu.ksu.canvas.requestOptions.GetUsersInAccountOptions;
 import edu.ksu.canvas.requestOptions.GetUsersInCourseOptions;
 
@@ -19,6 +20,7 @@ import java.lang.reflect.Type;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -33,9 +35,16 @@ public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements 
 
     @Override
     public Optional<User> createUser(User user) throws InvalidOauthTokenException, IOException {
+        return createUser(user, new CreateUserOptions());
+    }
+
+    @Override
+    public Optional<User> createUser(User user, CreateUserOptions options) throws InvalidOauthTokenException, IOException {
         String createdUrl = buildCanvasUrl("accounts/" + CanvasConstants.ACCOUNT_ID + "/users", Collections.emptyMap());
         LOG.debug("create URl for user creation : " + createdUrl);
-        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, user.toPostMap(serializeNulls));
+        Map<String, List<String>> parameterMap = options.getOptionsMap();
+        parameterMap.putAll(user.toPostMap(serializeNulls));
+        Response response = canvasMessenger.sendToCanvas(oauthToken, createdUrl, parameterMap);
         if (response.getErrorHappened() || (response.getResponseCode() != 200)) {
             LOG.debug("Failed to create user, error message: " + response.toString());
             return Optional.empty();

--- a/src/main/java/edu/ksu/canvas/interfaces/UserWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/UserWriter.java
@@ -2,6 +2,7 @@ package edu.ksu.canvas.interfaces;
 
 import edu.ksu.canvas.exception.InvalidOauthTokenException;
 import edu.ksu.canvas.model.User;
+import edu.ksu.canvas.requestOptions.CreateUserOptions;
 
 import java.io.IOException;
 import java.util.Optional;
@@ -15,6 +16,16 @@ public interface UserWriter extends CanvasWriter<User, UserWriter> {
      * @throws IOException When there is an error communicating with Canvas
      */
     Optional<User> createUser(User user) throws InvalidOauthTokenException, IOException;
+
+    /**
+     * Create a new user in Canvas
+     * @param user  user data for creating user account
+     * @param options the options for the user creation
+     * @return The newly created user
+     * @throws InvalidOauthTokenException When the supplied OAuth token is not valid
+     * @throws IOException When there is an error communicating with Canvas
+     */
+    Optional<User> createUser (User user, CreateUserOptions options) throws InvalidOauthTokenException, IOException;
 
 
     /**

--- a/src/main/java/edu/ksu/canvas/requestOptions/CreateUserOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/CreateUserOptions.java
@@ -1,0 +1,49 @@
+package edu.ksu.canvas.requestOptions;
+
+public class CreateUserOptions extends BaseOptions {
+
+    public CreateUserOptions termsOfUse(boolean accepted) {
+        addSingleItem("user[terms_of_use]", Boolean.toString(accepted));
+        return this;
+    }
+
+    public CreateUserOptions skipRegistration(boolean skipped) {
+        addSingleItem("user[skip_registration]", Boolean.toString(skipped));
+        return this;
+    }
+
+    public CreateUserOptions sendConfirmation(boolean send) {
+        addSingleItem("pseudonym[send_confirmation]", Boolean.toString(send));
+        return this;
+    }
+
+    public CreateUserOptions forceSelfRegistration(boolean force) {
+        addSingleItem("pseudonym[force_self_registration]", Boolean.toString(force));
+        return this;
+    }
+
+    public CreateUserOptions confirmationUrl(boolean confirmation) {
+        addSingleItem("communication_channel[confirmation_url]", Boolean.toString(confirmation));
+        return this;
+    }
+
+    public CreateUserOptions skipConfirmation(boolean skip) {
+        addSingleItem("communication_channel[skip_confirmation]", Boolean.toString(skip));
+        return this;
+    }
+
+    public CreateUserOptions forceValidations(boolean force) {
+        addSingleItem("force_validations", Boolean.toString(force));
+        return this;
+    }
+
+    public CreateUserOptions enableSisReactivation(boolean enable) {
+        addSingleItem("enable_sis_reactivation", Boolean .toString(enable));
+        return this;
+    }
+
+    public CreateUserOptions destination(String url) {
+        addSingleItem("destination", url);
+        return this;
+    }
+}


### PR DESCRIPTION
The creation of a user through the API supports options and this allows more control over how the user is created. As these don’t belong directly on the user object a new method for creating a user has been added and this takes the options as an additional parameter.