### PR TITLE
Switch from using log4j directly to slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -288,7 +288,7 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.25</version>
+      <version>1.7.27</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
@@ -332,6 +332,12 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.27</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -286,9 +286,9 @@
       <version>18.0</version>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.16</version>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
     </dependency>
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -291,6 +291,13 @@
       <version>1.7.27</version>
     </dependency>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.27</version>
+      <!-- This is so that TestLauncher has an implementation but projects using this library don't get it -->
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>4.5.2</version>

--- a/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
+++ b/src/main/java/edu/ksu/canvas/CanvasApiFactory.java
@@ -5,8 +5,8 @@ import edu.ksu.canvas.interfaces.*;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.net.RefreshingRestClient;
 import edu.ksu.canvas.oauth.OauthToken;
-
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
@@ -23,7 +23,7 @@ import java.util.Map;
 public class CanvasApiFactory {
 
     public static final Integer CANVAS_API_VERSION = 1;
-    private static final Logger LOG = Logger.getLogger(CanvasApiFactory.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CanvasApiFactory.class);
     private static final int DEFAULT_CONNECT_TIMEOUT_MS = 5000;
     private static final int DEFAULT_READ_TIMEOUT_MS = 120000;
     Map<Class<? extends CanvasReader>, Class<? extends BaseImpl>> readerMap;

--- a/src/main/java/edu/ksu/canvas/TestLauncher.java
+++ b/src/main/java/edu/ksu/canvas/TestLauncher.java
@@ -1,18 +1,17 @@
 package edu.ksu.canvas;
 
-import java.io.IOException;
-import java.util.List;
-
-import org.apache.log4j.Logger;
-
 import edu.ksu.canvas.interfaces.AccountReader;
 import edu.ksu.canvas.interfaces.CourseReader;
 import edu.ksu.canvas.model.Account;
 import edu.ksu.canvas.model.Course;
 import edu.ksu.canvas.oauth.NonRefreshableOauthToken;
 import edu.ksu.canvas.oauth.OauthToken;
-
 import edu.ksu.canvas.requestOptions.ListCurrentUserCoursesOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
 
 /**
  * A class with a main method that executes a couple of simple read-only requests
@@ -25,7 +24,7 @@ import edu.ksu.canvas.requestOptions.ListCurrentUserCoursesOptions;
  */
 public class TestLauncher {
 
-    private static final Logger LOG = Logger.getLogger(TestLauncher.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TestLauncher.class);
 
     private String canvasUrl;
     private OauthToken oauthToken;

--- a/src/main/java/edu/ksu/canvas/impl/AccountImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AccountImpl.java
@@ -12,7 +12,8 @@ import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.GetSubAccountsOptions;
 import edu.ksu.canvas.requestOptions.ListAccountOptions;
 import edu.ksu.canvas.util.CanvasURLBuilder;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -21,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class AccountImpl extends BaseImpl<Account, AccountReader, CanvasWriter> implements AccountReader {
-    private static final Logger LOG = Logger.getLogger(AccountImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AccountImpl.class);
 
     public AccountImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                        int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/AccountReportImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AccountReportImpl.java
@@ -10,7 +10,8 @@ import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.AccountReportOptions;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class AccountReportImpl extends BaseImpl<AccountReport, AccountReportReader, AccountReportWriter> implements AccountReportReader, AccountReportWriter {
-    private static final Logger LOG = Logger.getLogger(AccountReport.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AccountReport.class);
 
     public AccountReportImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                              int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/AccountReportSummaryImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AccountReportSummaryImpl.java
@@ -7,7 +7,8 @@ import edu.ksu.canvas.model.report.AccountReportSummary;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -15,7 +16,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class AccountReportSummaryImpl extends BaseImpl<AccountReportSummary, AccountReportSummaryReader, AccountReportSummaryWriter> implements AccountReportSummaryReader, AccountReportSummaryWriter {
-    private static final Logger LOG = Logger.getLogger(AccountReportSummaryImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AccountReportSummaryImpl.class);
 
     public AccountReportSummaryImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                                     int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/AdminImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AdminImpl.java
@@ -8,14 +8,15 @@ import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.ListAccountAdminsOptions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
 
 public class AdminImpl extends BaseImpl<AccountAdmin, AdminReader, AdminWriter> implements AdminReader, AdminWriter {
-    private static final Logger LOG = Logger.getLogger(AdminImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AdminImpl.class);
 
     public AdminImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                      int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/AssignmentGroupImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentGroupImpl.java
@@ -12,7 +12,8 @@ import edu.ksu.canvas.requestOptions.GetAssignmentGroupOptions;
 import edu.ksu.canvas.requestOptions.ListAssignmentGroupOptions;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -39,7 +40,7 @@ public class AssignmentGroupImpl extends BaseImpl<AssignmentGroup, AssignmentGro
                 paginationPageSize, serializeNulls);
     }
 
-    private static final Logger LOG = Logger.getLogger(AssignmentGroupImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AssignmentGroupImpl.class);
 
     @Override
     public Optional<AssignmentGroup> getAssignmentGroup(GetAssignmentGroupOptions options) throws IOException {

--- a/src/main/java/edu/ksu/canvas/impl/AssignmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentImpl.java
@@ -13,7 +13,8 @@ import edu.ksu.canvas.requestOptions.ListCourseAssignmentsOptions;
 import edu.ksu.canvas.requestOptions.ListUserAssignmentOptions;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -24,7 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class AssignmentImpl extends BaseImpl<Assignment, AssignmentReader, AssignmentWriter> implements AssignmentReader, AssignmentWriter{
-    private static final Logger LOG = Logger.getLogger(AssignmentReader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AssignmentReader.class);
 
     public AssignmentImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                           int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/AssignmentOverrideImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/AssignmentOverrideImpl.java
@@ -9,7 +9,8 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -18,7 +19,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class AssignmentOverrideImpl extends BaseImpl<AssignmentOverride, AssignmentOverrideReader, AssignmentOverrideWriter> implements AssignmentOverrideReader, AssignmentOverrideWriter {
-    private static final Logger LOG = Logger.getLogger(AssignmentOverrideImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AssignmentOverrideImpl.class);
 
 
     public AssignmentOverrideImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,

--- a/src/main/java/edu/ksu/canvas/impl/BaseImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/BaseImpl.java
@@ -14,7 +14,8 @@ import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.util.CanvasURLBuilder;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -33,7 +34,7 @@ import java.util.stream.Collectors;
 
 
 public abstract class BaseImpl<T, READERTYPE extends CanvasReader, WRITERTYPE extends CanvasWriter> implements CanvasReader<T, READERTYPE>, CanvasWriter<T,WRITERTYPE>{
-    private static final Logger LOG = Logger.getLogger(BaseImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BaseImpl.class);
 
     protected String canvasBaseUrl;
     protected Integer apiVersion;

--- a/src/main/java/edu/ksu/canvas/impl/CalendarEventImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/CalendarEventImpl.java
@@ -9,7 +9,8 @@ import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.DeleteCalendarEventOptions;
 import edu.ksu.canvas.requestOptions.ListCalendarEventsOptions;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -21,7 +22,7 @@ import java.util.Optional;
 
 public class CalendarEventImpl extends BaseImpl<CalendarEvent, CalendarReader, CalendarWriter> implements CalendarReader, CalendarWriter {
 
-    private static  final Logger LOG = Logger.getLogger(CalendarEventImpl.class);
+    private static  final Logger LOG = LoggerFactory.getLogger(CalendarEventImpl.class);
 
     /**
      * Construct a new CanvasApi class with an OAuth token

--- a/src/main/java/edu/ksu/canvas/impl/ContentMigrationImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/ContentMigrationImpl.java
@@ -9,7 +9,8 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.CreateCourseContentMigrationOptions;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -19,7 +20,7 @@ import java.util.Optional;
 
 public class ContentMigrationImpl extends BaseImpl<ContentMigration, ContentMigrationReader, ContentMigrationWriter> implements ContentMigrationReader, ContentMigrationWriter {
 
-    private static final Logger LOG = Logger.getLogger(ContentMigrationWriter.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ContentMigrationWriter.class);
 
     public ContentMigrationImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                       int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/ConversationImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/ConversationImpl.java
@@ -1,16 +1,6 @@
 package edu.ksu.canvas.impl;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.apache.log4j.Logger;
-
 import com.google.gson.reflect.TypeToken;
-
 import edu.ksu.canvas.interfaces.ConversationReader;
 import edu.ksu.canvas.interfaces.ConversationWriter;
 import edu.ksu.canvas.model.Conversation;
@@ -20,9 +10,18 @@ import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.AddMessageToConversationOptions;
 import edu.ksu.canvas.requestOptions.CreateConversationOptions;
 import edu.ksu.canvas.requestOptions.GetSingleConversationOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class ConversationImpl extends BaseImpl<Conversation, ConversationReader, ConversationWriter> implements ConversationReader, ConversationWriter {
-    private static final Logger LOG = Logger.getLogger(ConversationImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ConversationImpl.class);
 
     public ConversationImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                             int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
@@ -14,7 +14,8 @@ import edu.ksu.canvas.requestOptions.GetSingleCourseOptions;
 import edu.ksu.canvas.requestOptions.ListActiveCoursesInAccountOptions;
 import edu.ksu.canvas.requestOptions.ListCurrentUserCoursesOptions;
 import edu.ksu.canvas.requestOptions.ListUserCoursesOptions;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -26,7 +27,7 @@ import java.util.Optional;
 
 
 public class CourseImpl extends BaseImpl<Course, CourseReader, CourseWriter> implements CourseReader, CourseWriter {
-    private static final Logger LOG = Logger.getLogger(CourseReader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CourseReader.class);
 
     public CourseImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                       int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/CourseSettingsImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/CourseSettingsImpl.java
@@ -8,7 +8,8 @@ import edu.ksu.canvas.model.CourseSettings;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -17,7 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class CourseSettingsImpl extends BaseImpl<CourseSettings, CourseSettingsReader, CourseSettingsWriter> implements CourseSettingsReader, CourseSettingsWriter {
-    private static final Logger LOG = Logger.getLogger(CourseReader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CourseReader.class);
 
     public CourseSettingsImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                       int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentImpl.java
@@ -13,7 +13,8 @@ import edu.ksu.canvas.requestOptions.GetEnrollmentOptions;
 
 import edu.ksu.canvas.requestOptions.UnEnrollOptions;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -24,7 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class EnrollmentImpl extends BaseImpl<Enrollment, EnrollmentReader, EnrollmentWriter> implements EnrollmentReader,EnrollmentWriter {
-    private static final Logger LOG = Logger.getLogger(CourseReader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CourseReader.class);
 
     public EnrollmentImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                           int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/EnrollmentTermImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/EnrollmentTermImpl.java
@@ -10,7 +10,8 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.GetEnrollmentTermOptions;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class EnrollmentTermImpl extends BaseImpl<EnrollmentTerm, EnrollmentTermReader, EnrollmentTermWriter> implements EnrollmentTermReader, EnrollmentTermWriter {
-    private static final Logger LOG = Logger.getLogger(EnrollmentTermReader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(EnrollmentTermReader.class);
 
     public EnrollmentTermImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                               int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/ExternalToolImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/ExternalToolImpl.java
@@ -1,19 +1,8 @@
 package edu.ksu.canvas.impl;
 
-import java.io.IOException;
-import java.lang.reflect.Type;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
-
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.reflect.TypeToken;
-
 import edu.ksu.canvas.interfaces.ExternalToolReader;
 import edu.ksu.canvas.interfaces.ExternalToolWriter;
 import edu.ksu.canvas.model.ExternalTool;
@@ -21,9 +10,19 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.ListExternalToolsOptions;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 public class ExternalToolImpl extends BaseImpl<ExternalTool, ExternalToolReader, ExternalToolWriter> implements ExternalToolReader, ExternalToolWriter {
-    private static final Logger LOG = Logger.getLogger(ExternalToolImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ExternalToolImpl.class);
 
     public ExternalToolImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                             int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/GradingStandardImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/GradingStandardImpl.java
@@ -6,7 +6,8 @@ import edu.ksu.canvas.interfaces.GradingStandardWriter;
 import edu.ksu.canvas.model.GradingStandard;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -16,7 +17,7 @@ import java.util.Optional;
 
 public class GradingStandardImpl extends BaseImpl<GradingStandard, GradingStandardReader, GradingStandardWriter> implements GradingStandardReader, GradingStandardWriter{
 
-    private static final Logger LOG = Logger.getLogger(GradingStandardImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(GradingStandardImpl.class);
 
     public GradingStandardImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                             int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/GsonResponseParser.java
+++ b/src/main/java/edu/ksu/canvas/impl/GsonResponseParser.java
@@ -31,10 +31,11 @@ import java.util.Optional;
 
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GsonResponseParser implements ResponseParser {
-    private static final Logger LOG = Logger.getLogger(GsonResponseParser.class);
+    private static final Logger LOG = LoggerFactory.getLogger(GsonResponseParser.class);
 
     @Override
     public <T> List<T> parseToList(Type type, Response response) {

--- a/src/main/java/edu/ksu/canvas/impl/LoginImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/LoginImpl.java
@@ -11,7 +11,8 @@ import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -19,7 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class LoginImpl extends BaseImpl<Login, LoginReader, LoginWriter> implements LoginReader, LoginWriter {
-    private static final Logger LOG = Logger.getLogger(LoginImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(LoginImpl.class);
 
     public LoginImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                      int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/PageImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/PageImpl.java
@@ -7,7 +7,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.gson.reflect.TypeToken;
 
@@ -20,7 +21,7 @@ import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 
 public class PageImpl extends BaseImpl<Page, PageReader, PageWriter> implements PageReader, PageWriter {
-    private static final Logger LOG = Logger.getLogger(PageImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(PageImpl.class);
 
     public PageImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                     int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/ProgressImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/ProgressImpl.java
@@ -13,11 +13,12 @@ import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.Collections;
 import java.util.Optional;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ProgressImpl extends BaseImpl<Progress, ProgressReader, ProgressWriter> implements ProgressReader, ProgressWriter {
 
-    private static final Logger LOG = Logger.getLogger(ProgressImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(ProgressImpl.class);
 
     public ProgressImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                                 int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/QuizImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizImpl.java
@@ -7,7 +7,8 @@ import edu.ksu.canvas.model.assignment.Quiz;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -18,7 +19,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class QuizImpl extends BaseImpl<Quiz, QuizReader, QuizWriter> implements QuizReader, QuizWriter {
-    private static final Logger LOG = Logger.getLogger(QuizReader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QuizReader.class);
 
     public QuizImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                     int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/QuizQuestionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizQuestionImpl.java
@@ -9,7 +9,8 @@ import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.GetQuizQuestionsOptions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -17,7 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 public class QuizQuestionImpl extends BaseImpl<QuizQuestion, QuizQuestionReader, QuizQuestionWriter> implements QuizQuestionReader, QuizQuestionWriter {
-    private static final Logger LOG = Logger.getLogger(QuizQuestionImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QuizQuestionImpl.class);
 
     public QuizQuestionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                             int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/QuizSubmissionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizSubmissionImpl.java
@@ -13,7 +13,8 @@ import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.CompleteQuizSubmissionOptions;
 import edu.ksu.canvas.requestOptions.GetQuizSubmissionsOptions;
 import edu.ksu.canvas.requestOptions.StartQuizSubmissionOptions;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -22,7 +23,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class QuizSubmissionImpl extends BaseImpl<QuizSubmission, QuizSubmissionReader, QuizSubmissionWriter> implements QuizSubmissionReader, QuizSubmissionWriter {
-    private static final Logger LOG = Logger.getLogger(QuizSubmissionImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QuizSubmissionImpl.class);
 
      public QuizSubmissionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                                int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/QuizSubmissionQuestionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/QuizSubmissionQuestionImpl.java
@@ -22,7 +22,8 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.AnswerQuizQuestionOptions;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -30,7 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 public class QuizSubmissionQuestionImpl extends BaseImpl<QuizSubmissionQuestion, QuizSubmissionQuestionReader, QuizSubmissionQuestionWriter> implements QuizSubmissionQuestionReader, QuizSubmissionQuestionWriter {
-    private static final Logger LOG = Logger.getLogger(QuizSubmissionQuestionImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QuizSubmissionQuestionImpl.class);
 
     public QuizSubmissionQuestionImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                                       int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/RestCanvasMessenger.java
+++ b/src/main/java/edu/ksu/canvas/impl/RestCanvasMessenger.java
@@ -10,7 +10,8 @@ import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
@@ -24,7 +25,7 @@ import java.util.function.Consumer;
  * This class uses the canvas rest api to communicate with canvas
  */
 public class RestCanvasMessenger implements CanvasMessenger {
-    private static final Logger LOG = Logger.getLogger(RestCanvasMessenger.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RestCanvasMessenger.class);
     private RestClient restClient;
     private int connectTimeout;
     private int readTimeout;

--- a/src/main/java/edu/ksu/canvas/impl/RoleImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/RoleImpl.java
@@ -8,14 +8,15 @@ import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.ListRolesOptions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.List;
 
 public class RoleImpl extends BaseImpl<Role, RoleReader, RoleWriter> implements RoleReader, RoleWriter {
-    private static final Logger LOG = Logger.getLogger(RoleImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RoleImpl.class);
 
     public RoleImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                     int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/SectionsImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/SectionsImpl.java
@@ -12,7 +12,8 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -27,7 +28,7 @@ import java.util.stream.Collectors;
 public class SectionsImpl extends BaseImpl<Section, SectionReader, SectionWriter> implements SectionReader,
         SectionWriter {
 
-    private static final Logger LOG = Logger.getLogger(SectionReader.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SectionReader.class);
 
     public SectionsImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                         int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/SubmissionImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/SubmissionImpl.java
@@ -12,7 +12,8 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.MultipleSubmissionsOptions;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -20,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class SubmissionImpl extends BaseImpl<Submission, SubmissionReader, SubmissionWriter> implements SubmissionReader, SubmissionWriter{
-    private static final Logger LOG = Logger.getLogger(SubmissionImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SubmissionImpl.class);
 
     /**
      * Construct a new CanvasApi class with an OAuth token

--- a/src/main/java/edu/ksu/canvas/impl/TabImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/TabImpl.java
@@ -14,11 +14,12 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.net.RestClient;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.requestOptions.UpdateCourseTabOptions;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TabImpl extends BaseImpl<Tab, TabReader, TabWriter> implements TabReader, TabWriter {
 
-    private static final Logger LOG = Logger.getLogger(TabImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(TabImpl.class);
 
     public TabImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
             int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/impl/UserImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/UserImpl.java
@@ -13,7 +13,8 @@ import edu.ksu.canvas.requestOptions.CreateUserOptions;
 import edu.ksu.canvas.requestOptions.GetUsersInAccountOptions;
 import edu.ksu.canvas.requestOptions.GetUsersInCourseOptions;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -25,7 +26,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class UserImpl extends BaseImpl<User, UserReader, UserWriter> implements UserReader, UserWriter{
-    private static final Logger LOG = Logger.getLogger(UserImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UserImpl.class);
 
     public UserImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient,
                     int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {

--- a/src/main/java/edu/ksu/canvas/model/BaseCanvasModel.java
+++ b/src/main/java/edu/ksu/canvas/model/BaseCanvasModel.java
@@ -3,7 +3,8 @@ package edu.ksu.canvas.model;
 import edu.ksu.canvas.annotation.CanvasField;
 import edu.ksu.canvas.annotation.CanvasObject;
 import edu.ksu.canvas.impl.GsonResponseParser;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -17,7 +18,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 public abstract class BaseCanvasModel {
-    private static final Logger LOG = Logger.getLogger(BaseCanvasModel.class);
+    private static final Logger LOG = LoggerFactory.getLogger(BaseCanvasModel.class);
 
     /* Canvas has post parameter keys in non consistent formats. Occasionally they are 'class[field]' and other times
      * they are just 'field'. This method will create a map with the correct post keys and values based on the

--- a/src/main/java/edu/ksu/canvas/net/RefreshingRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/RefreshingRestClient.java
@@ -2,7 +2,8 @@ package edu.ksu.canvas.net;
 
 import edu.ksu.canvas.exception.InvalidOauthTokenException;
 import edu.ksu.canvas.oauth.OauthToken;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
@@ -17,7 +18,7 @@ import java.util.Map;
  * still fails, the error is thrown up to the caller.
  */
 public class RefreshingRestClient implements RestClient {
-    private static final Logger LOG = Logger.getLogger(RefreshingRestClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RefreshingRestClient.class);
     private RestClient restClient = new SimpleRestClient();
 
     @Override

--- a/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
+++ b/src/main/java/edu/ksu/canvas/net/SimpleRestClient.java
@@ -36,7 +36,10 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+
+import com.google.gson.Gson;
+import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
@@ -48,7 +51,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 public class SimpleRestClient implements RestClient {
-    private static final Logger LOG = Logger.getLogger(SimpleRestClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SimpleRestClient.class);
 
     private List<ErrorHandler> errorHandlers;
 

--- a/src/main/java/edu/ksu/canvas/oauth/OauthTokenRefresher.java
+++ b/src/main/java/edu/ksu/canvas/oauth/OauthTokenRefresher.java
@@ -15,17 +15,18 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.params.HttpConnectionParams;
 import org.apache.http.params.HttpParams;
 import org.apache.http.util.EntityUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
 
 import com.google.gson.Gson;
 
 import edu.ksu.canvas.impl.GsonResponseParser;
+import org.slf4j.LoggerFactory;
 
 
 public class OauthTokenRefresher implements Serializable {
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOG = Logger.getLogger(OauthTokenRefresher.class);
+    private static final Logger LOG = LoggerFactory.getLogger(OauthTokenRefresher.class);
 
     private static final int TIMEOUT_SECONDS = 10;
     private final String clientId;

--- a/src/main/java/edu/ksu/canvas/oauth/RefreshableOauthToken.java
+++ b/src/main/java/edu/ksu/canvas/oauth/RefreshableOauthToken.java
@@ -1,7 +1,8 @@
 package edu.ksu.canvas.oauth;
 
 import edu.ksu.canvas.exception.InvalidOauthTokenException;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Date;
@@ -9,7 +10,7 @@ import java.util.Date;
 public class RefreshableOauthToken implements OauthToken {
     private static final long serialVersionUID = 1L;
 
-    private static final Logger LOG = Logger.getLogger(RefreshableOauthToken.class);
+    private static final Logger LOG = LoggerFactory.getLogger(RefreshableOauthToken.class);
 
     private OauthTokenRefresher tokenRefresher;
     private String refreshToken;

--- a/src/main/java/edu/ksu/canvas/util/CanvasURLBuilder.java
+++ b/src/main/java/edu/ksu/canvas/util/CanvasURLBuilder.java
@@ -1,12 +1,14 @@
 package edu.ksu.canvas.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Map;
 import java.util.List;
 
-import org.apache.log4j.Logger;
 
 public class CanvasURLBuilder {
-    private static final Logger LOG = Logger.getLogger(CanvasURLBuilder.class);
+    private static final Logger LOG = LoggerFactory.getLogger(CanvasURLBuilder.class);
 
     /* Builds parameters in form of ?param[]=value1&param[]=value2&otherParam=someValue*/
     public static String buildCanvasUrl(String canvasBaseUrl, int canvasAPIVersion, String canvasMethod, Map<String, List<String>> parameters) {

--- a/src/main/java/edu/ksu/canvas/util/HttpParameterBuilder.java
+++ b/src/main/java/edu/ksu/canvas/util/HttpParameterBuilder.java
@@ -6,7 +6,8 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.List;
 import java.util.Map;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * This class transforms a map into a parameter string
@@ -15,7 +16,7 @@ import org.apache.log4j.Logger;
  * ?array[]=a&array[]=b&item=c
  */
 public class HttpParameterBuilder {
-    private static final Logger LOG = Logger.getLogger(HttpParameterBuilder.class);
+    private static final Logger LOG = LoggerFactory.getLogger(HttpParameterBuilder.class);
 
     public static String buildParameters(Map<String, List<String>> parameters) {
         return parameters.entrySet().stream()

--- a/src/test/java/edu/ksu/canvas/impl/SubmissionImplTest.java
+++ b/src/test/java/edu/ksu/canvas/impl/SubmissionImplTest.java
@@ -4,10 +4,11 @@ import edu.ksu.canvas.CanvasTestBase;
 import edu.ksu.canvas.interfaces.SubmissionWriter;
 import edu.ksu.canvas.model.Progress;
 import edu.ksu.canvas.requestOptions.MultipleSubmissionsOptions;
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -15,7 +16,7 @@ import java.util.Map;
 import java.util.Optional;
 
 public class SubmissionImplTest extends CanvasTestBase {
-    private static final Logger LOG = Logger.getLogger(SubmissionImplTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(SubmissionImplTest.class);
     public static final String COURSE_ID = "37836";
     public static final String SECTION_ID = "41478";
     public static final int ASSIGNEMNET_ID = 409522;

--- a/src/test/java/edu/ksu/canvas/net/FakeRestClient.java
+++ b/src/test/java/edu/ksu/canvas/net/FakeRestClient.java
@@ -4,7 +4,8 @@ import edu.ksu.canvas.constants.CanvasConstants;
 import edu.ksu.canvas.exception.InvalidOauthTokenException;
 import edu.ksu.canvas.oauth.OauthToken;
 import edu.ksu.canvas.util.JsonTestUtil;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.validation.constraints.NotNull;
 import java.io.IOException;
@@ -14,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 
 public class FakeRestClient implements RestClient {
-    private static final Logger LOG = Logger.getLogger(FakeRestClient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(FakeRestClient.class);
     public static int NO_TIMEOUT = 1000;
     private Map<String, Response> responseMap = new HashMap<>();
 

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentOverrideUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentOverrideUTest.java
@@ -13,7 +13,8 @@ import edu.ksu.canvas.model.assignment.AssignmentOverride;
 import edu.ksu.canvas.net.FakeRestClient;
 import edu.ksu.canvas.net.Response;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +24,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class AssignmentOverrideUTest extends CanvasTestBase {
-    private static final Logger LOG = Logger.getLogger(AssignmentRetrieverUTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AssignmentRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private AssignmentOverrideReader assignmentOverrideReader;

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentRetrieverUTest.java
@@ -10,18 +10,18 @@ import edu.ksu.canvas.net.FakeRestClient;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.requestOptions.GetSingleAssignmentOptions;
 import edu.ksu.canvas.requestOptions.ListCourseAssignmentsOptions;
-
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 import java.util.Optional;
 
 public class AssignmentRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = Logger.getLogger(AssignmentRetrieverUTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(AssignmentRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private AssignmentReader assignmentReader;

--- a/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/assignment/AssignmentRetrieverUTest.java
@@ -13,15 +13,12 @@ import edu.ksu.canvas.requestOptions.ListCourseAssignmentsOptions;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
 import java.util.Optional;
 
 public class AssignmentRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = LoggerFactory.getLogger(AssignmentRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private AssignmentReader assignmentReader;

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizQuestionRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizQuestionRetrieverUTest.java
@@ -13,15 +13,12 @@ import edu.ksu.canvas.util.CanvasURLBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
 import java.util.List;
 
 public class QuizQuestionRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = LoggerFactory.getLogger(QuizQuestionRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private QuizQuestionReader quizQuestionReader;

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizQuestionRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizQuestionRetrieverUTest.java
@@ -10,17 +10,18 @@ import edu.ksu.canvas.net.FakeRestClient;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.requestOptions.GetQuizQuestionsOptions;
 import edu.ksu.canvas.util.CanvasURLBuilder;
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
 import java.util.List;
 
 public class QuizQuestionRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = Logger.getLogger(QuizQuestionRetrieverUTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QuizQuestionRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private QuizQuestionReader quizQuestionReader;

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizRetrieverUTest.java
@@ -12,8 +12,6 @@ import edu.ksu.canvas.util.CanvasURLBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
@@ -21,7 +19,6 @@ import java.util.List;
 import java.util.Optional;
 
 public class QuizRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = LoggerFactory.getLogger(QuizRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private QuizReader quizReader;

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizRetrieverUTest.java
@@ -9,10 +9,11 @@ import edu.ksu.canvas.model.assignment.Quiz;
 import edu.ksu.canvas.net.FakeRestClient;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.util.CanvasURLBuilder;
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
@@ -20,7 +21,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class QuizRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = Logger.getLogger(QuizRetrieverUTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QuizRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private QuizReader quizReader;

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
@@ -14,15 +14,12 @@ import edu.ksu.canvas.util.CanvasURLBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
 import java.util.List;
 
 public class QuizSubmissionRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = LoggerFactory.getLogger(QuizSubmissionRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private QuizSubmissionReader quizSubmissionReader;

--- a/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/quiz/QuizSubmissionRetrieverUTest.java
@@ -11,17 +11,18 @@ import edu.ksu.canvas.net.FakeRestClient;
 import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.requestOptions.GetQuizSubmissionsOptions;
 import edu.ksu.canvas.util.CanvasURLBuilder;
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
 import java.util.List;
 
 public class QuizSubmissionRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = Logger.getLogger(QuizSubmissionRetrieverUTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(QuizSubmissionRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private QuizSubmissionReader quizSubmissionReader;

--- a/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
@@ -10,10 +10,11 @@ import edu.ksu.canvas.net.Response;
 import edu.ksu.canvas.requestOptions.GetUsersInAccountOptions;
 import edu.ksu.canvas.requestOptions.GetUsersInCourseOptions;
 import edu.ksu.canvas.util.CanvasURLBuilder;
-import org.apache.log4j.Logger;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
@@ -21,7 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class UserRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = Logger.getLogger(UserRetrieverUTest.class);
+    private static final Logger LOG = LoggerFactory.getLogger(UserRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private UserReader userReader;

--- a/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/user/UserRetrieverUTest.java
@@ -13,8 +13,6 @@ import edu.ksu.canvas.util.CanvasURLBuilder;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Collections;
@@ -22,7 +20,6 @@ import java.util.List;
 import java.util.Optional;
 
 public class UserRetrieverUTest extends CanvasTestBase {
-    private static final Logger LOG = LoggerFactory.getLogger(UserRetrieverUTest.class);
     @Autowired
     private FakeRestClient fakeRestClient;
     private UserReader userReader;

--- a/src/test/java/edu/ksu/canvas/util/JsonTestUtil.java
+++ b/src/test/java/edu/ksu/canvas/util/JsonTestUtil.java
@@ -1,12 +1,13 @@
 package edu.ksu.canvas.util;
 
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 
 public class JsonTestUtil {
-    private static final Logger LOG = Logger.getLogger(JsonTestUtil.class);
+    private static final Logger LOG = LoggerFactory.getLogger(JsonTestUtil.class);
     public static String loadJson(String fileName, Class clazz) {
         try {
             InputStream stream = clazz.getResourceAsStream(fileName);


### PR DESCRIPTION
This allow consumers of the library to pick the logging framework they want to use. If you want all the logging events to go through log4j, just add this as a dependency to the consuming application's pom.xml:
```
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-log4j12</artifactId>
      <version>1.7.27</version>
    </dependency>
```