### PR TITLE
The External Tools now have a version property.

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/ExternalTool.java
+++ b/src/main/java/edu/ksu/canvas/model/ExternalTool.java
@@ -24,6 +24,8 @@ public class ExternalTool extends BaseCanvasModel implements Serializable {
     private String configType;
     private String configXml;
     private String configUrl;
+    // The LTI version eg, 1.1 or 1.3
+    private String version;
     private Map<String, String> customFields;
     //These navigation settings are problematic. The possible values in these maps are documented
     //at https://canvas.instructure.com/doc/api/external_tools.html#method.external_tools.create
@@ -171,6 +173,14 @@ public class ExternalTool extends BaseCanvasModel implements Serializable {
 
     public void setConfigUrl(String configUrl) {
         this.configUrl = configUrl;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     /**


### PR DESCRIPTION
The external tools have a version property that says what LTI version the tool is using (eg 1.1 or 1.3). Although this isn’t documented on https://canvas.instructure.com/doc/api/external_tools.html#method.external_tools.index it appears to be returned without asking for any additional options.