### PR TITLE
Add assignment_visibility parameter to the assignment object

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/assignment/Assignment.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/Assignment.java
@@ -57,6 +57,7 @@ public class Assignment extends BaseCanvasModel implements Serializable{
     private String lockExplanation;
     private Boolean notifyOfUpdate;
     private Boolean omitFromFinalGrade;
+    private List<String> assignmentVisibility;
 
     public Integer getId() {
         return id;
@@ -405,6 +406,15 @@ public class Assignment extends BaseCanvasModel implements Serializable{
 
     public void setOmitFromFinalGrade(Boolean omitFromFinalGrade) {
         this.omitFromFinalGrade = omitFromFinalGrade;
+    }
+    
+    @CanvasField(postKey = "assignment_visibility")
+    public List<String> getAssignmentVisibility() {
+        return assignmentVisibility;
+    }
+
+    public void setAssignmentVisibility(List<String> assignmentVisibility) {
+        this.assignmentVisibility = assignmentVisibility;
     }
 
     public class ExternalToolTagAttribute implements Serializable {

--- a/src/test/resources/SampleJson/assignment/AssignmentList.json
+++ b/src/test/resources/SampleJson/assignment/AssignmentList.json
@@ -58,7 +58,7 @@
       "points_possible": 12
     },
     "rubric": "",
-    "assignment_visibility": "[137,381,572]",
+    "assignment_visibility": ["137","381","572"],
     "overrides": ""
   },
   {
@@ -120,7 +120,7 @@
       "points_possible": 12
     },
     "rubric": "",
-    "assignment_visibility": "[137,381,572]",
+    "assignment_visibility": ["137","381","572"],
     "overrides": ""
   }
 ]


### PR DESCRIPTION
Hi @ToeBee, hope everything goes well.

I've added support for a missing parameter in the assignments' object, the list of users assigned to a particular assignment.

I tested it with a client and works fine, would you mind releasing a minor version 1.0.24 with this change?

Thank you so much for the wonderful work.