### PR TITLE
Assignment Groups: Add support for grading rules

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/assignment/AssignmentGroup.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/AssignmentGroup.java
@@ -15,6 +15,7 @@ public class AssignmentGroup extends BaseCanvasModel implements Serializable {
     Double groupWeight;
     String sisSourceId;
     List<Assignment> assignments;
+    GradingRules rules;
 
     public Integer getId() {
         return id;
@@ -70,4 +71,16 @@ public class AssignmentGroup extends BaseCanvasModel implements Serializable {
     public void setAssignments(List<Assignment> assignments) {
         this.assignments = assignments;
     }
+
+    /**
+     * @return the grading rules that this Assignment Group has
+     */
+    public GradingRules getGradingRules() {
+        return rules;
+    }
+
+    public void setGradingRules(GradingRules rules) {
+        this.rules = rules;
+    }
+
 }

--- a/src/main/java/edu/ksu/canvas/model/assignment/GradingRules.java
+++ b/src/main/java/edu/ksu/canvas/model/assignment/GradingRules.java
@@ -1,0 +1,45 @@
+package edu.ksu.canvas.model.assignment;
+
+import java.io.Serializable;
+import java.util.List;
+
+import edu.ksu.canvas.model.BaseCanvasModel;
+
+/**
+ * Object to represent Grading Rules which can optionally be embedded inside of an assignment group object
+ */
+public class GradingRules extends BaseCanvasModel implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    // Number of lowest scores to be dropped for each user.
+    private Integer dropLowest;
+    // Number of highest scores to be dropped for each user.
+    private Integer dropHighest;
+    // Assignment IDs that should never be dropped.
+    private List<Integer> neverDrop;
+
+    public Integer getDropLowest() {
+        return dropLowest;
+    }
+
+    public void setDropLowest(Integer dropLowest) {
+        this.dropLowest = dropLowest;
+    }
+
+    public Integer getDropHighest() {
+        return dropHighest;
+    }
+
+    public void setDropHighest(Integer dropHighest) {
+        this.dropHighest = dropHighest;
+    }
+
+    public List<Integer> getNeverDrop() {
+        return neverDrop;
+    }
+
+    public void setNeverDrop(List<Integer> neverDrop) {
+        this.neverDrop = neverDrop;
+    }
+
+}


### PR DESCRIPTION
Added support for grading rules objects that are embedded inside the assignment group objects.

https://canvas.instructure.com/doc/api/assignment_groups.html#AssignmentGroup