### PR TITLE
Allow getting of a single course in an account.

### DIFF
--- a/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/CourseImpl.java
@@ -57,6 +57,14 @@ public class CourseImpl extends BaseImpl<Course, CourseReader, CourseWriter> imp
         return retrieveCourseFromCanvas(oauthToken, url);
     }
 
+    @Override
+    public Optional<Course> getSingleCourse(String accountId, GetSingleCourseOptions options) throws IOException {
+        LOG.debug("getting course " + options.getCourseId() + " in account "+ accountId);
+        String url = buildCanvasUrl("accounts/"+ accountId+ "/courses/"+ options.getCourseId(), options.getOptionsMap());
+        LOG.debug("Final URL of API call: " + url);
+        return retrieveCourseFromCanvas(oauthToken, url);
+    }
+
     private Optional<Course> retrieveCourseFromCanvas(OauthToken oauthToken, String url) throws IOException {
         Response response = canvasMessenger.getSingleResponseFromCanvas(oauthToken, url);
         if (response.getErrorHappened() || response.getResponseCode() != 200) {

--- a/src/main/java/edu/ksu/canvas/interfaces/CourseReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/CourseReader.java
@@ -39,6 +39,13 @@ public interface CourseReader extends CanvasReader<Course, CourseReader> {
      */
      Optional<Course> getSingleCourse(GetSingleCourseOptions options) throws IOException;
 
+    /**
+     * Retrieve a specific course from a Canvas account by its Canvas ID number
+     * @param accountId The account to look for the course in.
+     * @param options The object holding options for this API call
+     * @return The course returned by Canvas or an empty Optional
+     * @throws IOException When there is an error communicating with Canvas
+     */
     Optional<Course> getSingleCourse(String accountId, GetSingleCourseOptions options) throws IOException;
 
     /**

--- a/src/main/java/edu/ksu/canvas/interfaces/CourseReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/CourseReader.java
@@ -39,7 +39,9 @@ public interface CourseReader extends CanvasReader<Course, CourseReader> {
      */
      Optional<Course> getSingleCourse(GetSingleCourseOptions options) throws IOException;
 
-     /**
+    Optional<Course> getSingleCourse(String accountId, GetSingleCourseOptions options) throws IOException;
+
+    /**
       * Retrieve a list of all courses on a given account
       * @param options AccountCourseListOptions object representing params to this API call
       * @return List of courses in the account


### PR DESCRIPTION
Adding support for this call allows you to search in just one account. This is useful when you don't have permissions for the top account or when you are wanting to test code by running it in a small sub-account.