### PR TITLE
Model attributes from integer to long

### DIFF
--- a/src/main/java/edu/ksu/canvas/model/Account.java
+++ b/src/main/java/edu/ksu/canvas/model/Account.java
@@ -17,9 +17,9 @@ public class Account extends BaseCanvasModel implements Serializable {
     private String name;
     private Integer parentAccountId; // The account's parent ID, or null if this is the root account
     private Integer rootAccountId; // The ID of the root account, or null if this is the root account
-    private Integer defaultStorageQuotaMb;
-    private Integer defaultUserStorageQuotaMb;
-    private Integer defaultGroupStorageQuotaMb;
+    private Long defaultStorageQuotaMb;
+    private Long defaultUserStorageQuotaMb;
+    private Long defaultGroupStorageQuotaMb;
     private String defaultTimeZone;
     private String sisAccountId;
     private String integrationId; // currently unused, expect it to be null
@@ -63,29 +63,29 @@ public class Account extends BaseCanvasModel implements Serializable {
     }
 
     @CanvasField(postKey = "default_storage_quota_mb")
-    public Integer getDefaultStorageQuotaMb() {
+    public Long getDefaultStorageQuotaMb() {
         return defaultStorageQuotaMb;
     }
 
-    public void setDefaultStorageQuotaMb(Integer defaultStorageQuotaMb) {
+    public void setDefaultStorageQuotaMb(Long defaultStorageQuotaMb) {
         this.defaultStorageQuotaMb = defaultStorageQuotaMb;
     }
 
     @CanvasField(postKey = "default_user_storage_quota_mb")
-    public Integer getDefaultUserStorageQuotaMb() {
+    public Long getDefaultUserStorageQuotaMb() {
         return defaultUserStorageQuotaMb;
     }
 
-    public void setDefaultUserStorageQuotaMb(Integer defaultUserStorageQuotaMb) {
+    public void setDefaultUserStorageQuotaMb(Long defaultUserStorageQuotaMb) {
         this.defaultUserStorageQuotaMb = defaultUserStorageQuotaMb;
     }
 
     @CanvasField(postKey = "default_group_storage_quota_mb")
-    public Integer getDefaultGroupStorageQuotaMb() {
+    public Long getDefaultGroupStorageQuotaMb() {
         return defaultGroupStorageQuotaMb;
     }
 
-    public void setDefaultGroupStorageQuotaMb(Integer defaultGroupStorageQuotaMb) {
+    public void setDefaultGroupStorageQuotaMb(Long defaultGroupStorageQuotaMb) {
         this.defaultGroupStorageQuotaMb = defaultGroupStorageQuotaMb;
     }
 

--- a/src/main/java/edu/ksu/canvas/model/Conversation.java
+++ b/src/main/java/edu/ksu/canvas/model/Conversation.java
@@ -12,7 +12,7 @@ import edu.ksu.canvas.annotation.CanvasObject;
 public class Conversation extends BaseCanvasModel implements Serializable {
     public static final long serialVersionUID = 1L;
 
-    private Integer id;
+    private Long id;
     private String subject;
     private ConversationMessageState workflowState;
     private String lastMessage;
@@ -38,8 +38,8 @@ public class Conversation extends BaseCanvasModel implements Serializable {
     public enum ConversationFlags { last_author, attachments, media_objects }
 
     public class Message {
-        private Integer id;
-        private Integer authorId;
+        private Long id;
+        private Long authorId;
         private Date createdAt;
         private Boolean generated;
         private String body;
@@ -48,19 +48,19 @@ public class Conversation extends BaseCanvasModel implements Serializable {
         private Object mediaComment;
         private List<Integer> participatingUserIds;
 
-        public Integer getId() {
+        public Long getId() {
             return id;
         }
 
-        public void setId(Integer id) {
+        public void setId(Long id) {
             this.id = id;
         }
 
-        public Integer getAuthorId() {
+        public Long getAuthorId() {
             return authorId;
         }
 
-        public void setAuthorId(Integer authorId) {
+        public void setAuthorId(Long authorId) {
             this.authorId = authorId;
         }
 
@@ -124,17 +124,17 @@ public class Conversation extends BaseCanvasModel implements Serializable {
     public class MessageParticipant implements Serializable {
         private static final long serialVersionUID = 1L;
 
-        private Integer id;
+        private Long id;
         private String name;
         private Object commonCourses; //TODO: Refine this object type
         private Object commonGroups; //TODO: Refine this object type
         private String avatarUrl;
 
-        public Integer getId() {
+        public Long getId() {
             return id;
         }
 
-        public void setId(Integer id) {
+        public void setId(Long id) {
             this.id = id;
         }
 
@@ -171,11 +171,11 @@ public class Conversation extends BaseCanvasModel implements Serializable {
         }
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/main/java/edu/ksu/canvas/model/Course.java
+++ b/src/main/java/edu/ksu/canvas/model/Course.java
@@ -19,12 +19,12 @@ public class Course extends BaseCanvasModel implements Serializable {
     private Integer accountId;
     private String courseCode;
     private String defaultView;
-    private Integer id;
+    private Long id;
     private String name;
     private Date startAt;
     private Date endAt;
     private Boolean publicSyllabus;
-    private Integer storageQuotaMb;
+    private Long storageQuotaMb;
     private Boolean hideFinalGrades;
     private Boolean applyAssignmentGroupWeights;
     private String sisCourseId;
@@ -93,11 +93,11 @@ public class Course extends BaseCanvasModel implements Serializable {
         this.defaultView = defaultView;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 
@@ -137,11 +137,11 @@ public class Course extends BaseCanvasModel implements Serializable {
         this.publicSyllabus = publicSyllabus;
     }
 
-    public Integer getStorageQuotaMb() {
+    public Long getStorageQuotaMb() {
         return storageQuotaMb;
     }
 
-    public void setStorageQuotaMb(Integer storageQuotaMb) {
+    public void setStorageQuotaMb(Long storageQuotaMb) {
         this.storageQuotaMb = storageQuotaMb;
     }
 

--- a/src/main/java/edu/ksu/canvas/model/Enrollment.java
+++ b/src/main/java/edu/ksu/canvas/model/Enrollment.java
@@ -16,7 +16,7 @@ public class Enrollment extends BaseCanvasModel implements Serializable {
     private static final long serialVersionUID = 3L;
 
     private long id;
-    private Integer courseId;
+    private Long courseId;
     private String sisCourseId;
     private String courseIntegrationId;
     private String courseSectionId;
@@ -57,11 +57,11 @@ public class Enrollment extends BaseCanvasModel implements Serializable {
         this.roleId = roleId;
     }
 
-    public Integer getCourseId() {
+    public Long getCourseId() {
         return courseId;
     }
 
-    public void setCourseId(Integer courseId) {
+    public void setCourseId(Long courseId) {
         this.courseId = courseId;
     }
 

--- a/src/test/java/edu/ksu/canvas/tests/course/CourseManagerUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/CourseManagerUTest.java
@@ -45,7 +45,7 @@ public class CourseManagerUTest extends CanvasTestBase {
     @Test
     public void testCourseUpdate() throws IOException {
         Course newCourse = new Course();
-        newCourse.setId(new Integer(ARBITRARY_COURSE_ID));
+        newCourse.setId(new Long(ARBITRARY_COURSE_ID));
         newCourse.setCourseCode("UpdatedSeleniumTestCourseCode");
         newCourse.setName("UpdatedSeleniumTestName");
         String url = baseUrl + "/api/v1/courses/" + ARBITRARY_COURSE_ID;

--- a/src/test/java/edu/ksu/canvas/tests/course/DropCourseUTest.java
+++ b/src/test/java/edu/ksu/canvas/tests/course/DropCourseUTest.java
@@ -31,7 +31,7 @@ public class DropCourseUTest extends CanvasTestBase {
         String url = baseUrl + "/api/v1/courses/25/enrollments";
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentResponse.json");
         Enrollment enrollment = new Enrollment();
-        enrollment.setCourseId(25);
+        enrollment.setCourseId(25L);
         enrollment.setUserId("78839");
         Optional<Enrollment> enrollmentResponse = enrollmentsWriter.enrollUser(enrollment);
         Assert.assertTrue(25==enrollmentResponse.get().getCourseId());
@@ -40,7 +40,7 @@ public class DropCourseUTest extends CanvasTestBase {
     }
 
     @Test
-    public void  testDropEnrolledUser() throws IOException {
+    public void testDropEnrolledUser() throws IOException {
         String url = baseUrl + "/api/v1/courses/25/enrollments/355047";
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentDeleteResponse.json");
         Optional<Enrollment> dropResponse = enrollmentsWriter.dropUser("25", "355047");
@@ -54,7 +54,7 @@ public class DropCourseUTest extends CanvasTestBase {
         String url = baseUrl + "/api/v1/courses/25/enrollments?as_user_id=" + CanvasConstants.MASQUERADE_SIS_USER + ":" + userId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentResponse.json");
         Enrollment enrollment = new Enrollment();
-        enrollment.setCourseId(25);
+        enrollment.setCourseId(25L);
         enrollment.setUserId("78839");
         Optional<Enrollment> enrollmentResponse = enrollmentsWriter.writeAsSisUser(userId).enrollUser(enrollment);
         Assert.assertTrue(25==enrollmentResponse.get().getCourseId());
@@ -63,7 +63,7 @@ public class DropCourseUTest extends CanvasTestBase {
     }
 
     @Test
-    public void  testSisUserMasqueradeDropEnrolledUser() throws IOException {
+    public void testSisUserMasqueradeDropEnrolledUser() throws IOException {
         String userId = "899123456";
         String url = baseUrl + "/api/v1/courses/25/enrollments/355047?as_user_id=" + CanvasConstants.MASQUERADE_SIS_USER + ":" + userId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentDeleteResponse.json");
@@ -78,7 +78,7 @@ public class DropCourseUTest extends CanvasTestBase {
         String url = baseUrl + "/api/v1/courses/25/enrollments?as_user_id=" + userId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentResponse.json");
         Enrollment enrollment = new Enrollment();
-        enrollment.setCourseId(25);
+        enrollment.setCourseId(25L);
         enrollment.setUserId("78839");
         Optional<Enrollment> enrollmentResponse = enrollmentsWriter.writeAsCanvasUser(userId).enrollUser(enrollment);
         Assert.assertTrue(25==enrollmentResponse.get().getCourseId());
@@ -87,7 +87,7 @@ public class DropCourseUTest extends CanvasTestBase {
     }
 
     @Test
-    public void  testCanvasUserMasqueradeDropEnrolledUser() throws IOException {
+    public void testCanvasUserMasqueradeDropEnrolledUser() throws IOException {
         String userId = "899123456";
         String url = baseUrl + "/api/v1/courses/25/enrollments/355047?as_user_id=" + userId;
         fakeRestClient.addSuccessResponse(url, "SampleJson/EnrollmentDeleteResponse.json");


### PR DESCRIPTION
We are currently using this library and ran across the same issue report to you back in May 2020, https://github.com/kstateome/canvas-api/issues/134. I have forked your library and changed all storage quota model attributes from integer to long, plus updated a few model ids from integer to long to be in compliance with Canvas documentation.