### PR TITLE
Register ClassMap Via Reflection & DiscussionTopic (Reader Only)

### DIFF
--- a/src/main/java/edu/ksu/canvas/TestLauncher.java
+++ b/src/main/java/edu/ksu/canvas/TestLauncher.java
@@ -26,15 +26,15 @@ public class TestLauncher {
 
     private static final Logger LOG = LoggerFactory.getLogger(TestLauncher.class);
 
-    private String canvasUrl;
-    private OauthToken oauthToken;
+    private final String canvasUrl;
+    private final OauthToken oauthToken;
 
     public static void main(String[] args) {
 
         String canvasUrl = null;
         String oauthToken = null;
         if(args.length != 4) {
-            LOG.error("Must supply two arguments: --canvas_url http://instance.instructure.com --token [Manually generated token]");
+            LOG.error("Must supply two arguments: --canvas_url https://<instance>.instructure.com --token [Manually generated token]");
             System.exit(1);
         }
         for(int i=0; i < args.length; i++) {
@@ -53,7 +53,7 @@ public class TestLauncher {
 
         TestLauncher launcher = new TestLauncher(canvasUrl, oauthToken);
         try {
-            launcher.getRootAccount();
+            //launcher.getRootAccount(); No permission for this as a student?
             launcher.getOwnCourses();
         } catch(Exception e) {
             LOG.error("Problem while executing example methods", e);

--- a/src/main/java/edu/ksu/canvas/TestLauncher.java
+++ b/src/main/java/edu/ksu/canvas/TestLauncher.java
@@ -2,10 +2,13 @@ package edu.ksu.canvas;
 
 import edu.ksu.canvas.interfaces.AccountReader;
 import edu.ksu.canvas.interfaces.CourseReader;
+import edu.ksu.canvas.interfaces.DiscussionTopicReader;
 import edu.ksu.canvas.model.Account;
 import edu.ksu.canvas.model.Course;
+import edu.ksu.canvas.model.DiscussionTopic;
 import edu.ksu.canvas.oauth.NonRefreshableOauthToken;
 import edu.ksu.canvas.oauth.OauthToken;
+import edu.ksu.canvas.requestOptions.GetSingleDiscussionTopicOptions;
 import edu.ksu.canvas.requestOptions.ListCurrentUserCoursesOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,8 +56,9 @@ public class TestLauncher {
 
         TestLauncher launcher = new TestLauncher(canvasUrl, oauthToken);
         try {
-            //launcher.getRootAccount(); No permission for this as a student?
+            //launcher.getRootAccount();
             launcher.getOwnCourses();
+            launcher.getDiscussionTopics();
         } catch(Exception e) {
             LOG.error("Problem while executing example methods", e);
         }
@@ -63,6 +67,14 @@ public class TestLauncher {
     public TestLauncher(String canvasUrl, String tokenString) {
         this.canvasUrl = canvasUrl;
         this.oauthToken = new NonRefreshableOauthToken(tokenString);
+    }
+
+    public void getDiscussionTopics() throws IOException {
+        CanvasApiFactory apiFactory = new CanvasApiFactory(canvasUrl);
+        DiscussionTopicReader topicReader = apiFactory.getReader(DiscussionTopicReader.class, oauthToken);
+        DiscussionTopic topic = topicReader.getDiscussionTopic(
+                new GetSingleDiscussionTopicOptions("whatever", "replaced_this_before_committing", GetSingleDiscussionTopicOptions.IdType.COURSES)).get();
+        System.out.println(topic.getTitle());
     }
 
     public void getRootAccount() throws IOException {

--- a/src/main/java/edu/ksu/canvas/annotation/AbstainRegister.java
+++ b/src/main/java/edu/ksu/canvas/annotation/AbstainRegister.java
@@ -1,0 +1,11 @@
+package edu.ksu.canvas.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AbstainRegister {
+}

--- a/src/main/java/edu/ksu/canvas/impl/DiscussionTopicImpl.java
+++ b/src/main/java/edu/ksu/canvas/impl/DiscussionTopicImpl.java
@@ -1,0 +1,57 @@
+package edu.ksu.canvas.impl;
+
+import com.google.gson.reflect.TypeToken;
+import edu.ksu.canvas.interfaces.DiscussionTopicReader;
+import edu.ksu.canvas.interfaces.DiscussionTopicWriter;
+import edu.ksu.canvas.model.DiscussionTopic;
+import edu.ksu.canvas.net.Response;
+import edu.ksu.canvas.net.RestClient;
+import edu.ksu.canvas.oauth.OauthToken;
+import edu.ksu.canvas.requestOptions.GetSingleDiscussionTopicOptions;
+import edu.ksu.canvas.requestOptions.ListDiscussionTopicsOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public class DiscussionTopicImpl extends BaseImpl<DiscussionTopic, DiscussionTopicReader, DiscussionTopicWriter> implements DiscussionTopicReader, DiscussionTopicWriter {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DiscussionTopicImpl.class);
+
+
+    public DiscussionTopicImpl(String canvasBaseUrl, Integer apiVersion, OauthToken oauthToken, RestClient restClient, int connectTimeout, int readTimeout, Integer paginationPageSize, Boolean serializeNulls) {
+        super(canvasBaseUrl, apiVersion, oauthToken, restClient, connectTimeout, readTimeout, paginationPageSize, serializeNulls);
+    }
+
+
+    @Override
+    public List<DiscussionTopic> listDiscussionTopics(ListDiscussionTopicsOptions options) throws IOException {
+        LOG.debug("Getting discussion topics for course/group: {}", options.getCourseOrGroupId());
+        String url = buildCanvasUrl(options.getStringIdType() + "/" + options.getCourseOrGroupId() + "/discussion_topics", options.getOptionsMap());
+        return getListFromCanvas(url);
+    }
+
+    @Override
+    public Optional<DiscussionTopic> getDiscussionTopic(GetSingleDiscussionTopicOptions options) throws IOException {
+        LOG.debug("Getting discussion topic with id: {} for course/group: {}", options.getDiscussionId(), options.getCourseOrGroupId());
+        Response response = canvasMessenger.getSingleResponseFromCanvas(oauthToken, buildCanvasUrl(options.getStringIdType() + "/" + options.getCourseOrGroupId() + "/discussion_topics/" + options.getDiscussionId(), options.getOptionsMap()));
+        if (response.getErrorHappened() || response.getResponseCode() != 200) {
+            return Optional.empty();
+        }
+        return responseParser.parseToObject(DiscussionTopic.class, response);
+    }
+
+    @Override
+    protected Type listType() {
+        return new TypeToken<List<DiscussionTopic>>(){}.getType();
+    }
+
+    @Override
+    protected Class<DiscussionTopic> objectType() {
+        return DiscussionTopic.class;
+    }
+}

--- a/src/main/java/edu/ksu/canvas/interfaces/CanvasReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/CanvasReader.java
@@ -1,6 +1,8 @@
 package edu.ksu.canvas.interfaces;
 
 
+import edu.ksu.canvas.impl.BaseImpl;
+
 import java.util.List;
 import java.util.function.Consumer;
 

--- a/src/main/java/edu/ksu/canvas/interfaces/CourseReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/CourseReader.java
@@ -24,7 +24,7 @@ public interface CourseReader extends CanvasReader<Course, CourseReader> {
      List<Course> listCurrentUserCourses(ListCurrentUserCoursesOptions options) throws IOException;
 
     /**
-     * Returns the list of active courses for the a user
+     * Returns the list of active courses for the user
      * @param options The object holding options for this API call
      * @return List of courses for the user matching any optional criteria
      * @throws IOException When there is an error communicating with Canvas

--- a/src/main/java/edu/ksu/canvas/interfaces/DiscussionTopicReader.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/DiscussionTopicReader.java
@@ -1,0 +1,16 @@
+package edu.ksu.canvas.interfaces;
+
+import edu.ksu.canvas.model.DiscussionTopic;
+import edu.ksu.canvas.requestOptions.GetSingleDiscussionTopicOptions;
+import edu.ksu.canvas.requestOptions.ListDiscussionTopicsOptions;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+
+public interface DiscussionTopicReader extends CanvasReader<DiscussionTopic, DiscussionTopicReader> {
+
+    List<DiscussionTopic> listDiscussionTopics(ListDiscussionTopicsOptions options) throws IOException;
+
+    Optional<DiscussionTopic> getDiscussionTopic(GetSingleDiscussionTopicOptions options) throws IOException;
+}

--- a/src/main/java/edu/ksu/canvas/interfaces/DiscussionTopicWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/DiscussionTopicWriter.java
@@ -1,0 +1,6 @@
+package edu.ksu.canvas.interfaces;
+
+import edu.ksu.canvas.model.DiscussionTopic;
+
+public interface DiscussionTopicWriter extends CanvasWriter<DiscussionTopic, DiscussionTopicWriter> {
+}

--- a/src/main/java/edu/ksu/canvas/interfaces/EnrollmentTermWriter.java
+++ b/src/main/java/edu/ksu/canvas/interfaces/EnrollmentTermWriter.java
@@ -1,8 +1,10 @@
 package edu.ksu.canvas.interfaces;
 
 
+import edu.ksu.canvas.annotation.AbstainRegister;
 import edu.ksu.canvas.model.EnrollmentTerm;
 
+@AbstainRegister
 public interface EnrollmentTermWriter extends CanvasWriter<EnrollmentTerm, EnrollmentTermWriter> {
 
 }

--- a/src/main/java/edu/ksu/canvas/model/DiscussionTopic.java
+++ b/src/main/java/edu/ksu/canvas/model/DiscussionTopic.java
@@ -1,0 +1,316 @@
+package edu.ksu.canvas.model;
+
+import edu.ksu.canvas.annotation.CanvasField;
+
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+
+public class DiscussionTopic extends BaseCanvasModel implements Serializable {
+
+    public static final long serialVersionUID = 1L;
+
+    private Long id;
+    private String title;
+    private String message;
+    private String htmlUrl;
+    private Date postedAt;
+    private Date lastReplyAt;
+    private Boolean requireInitialPost;
+    private Boolean userCanSeePosts;
+    private Long discussionSubentryCount;
+    private String readState;
+    private Long unreadCount;
+    private Boolean subscribed;
+    private String subscriptionHold;
+    private Long assignmentId;
+    private Date delayedPostAt;
+    private Boolean published;
+    private Boolean locked;
+    private Boolean pinned;
+    private Boolean lockedForUser;
+    private String lockInfo;
+    private String lockExplanation;
+    private String userName;
+    // group_topic_children
+    private Long rootTopicId;
+    private String podcastUrl;
+    private String discussionType;
+    private Long groupCategoryId;
+    private List<File> attachments;
+    // permissions
+    private Boolean allowRating;
+    private Boolean onlyGradersCanRate;
+    private Boolean sortByRating;
+    // TODO: finish adding fields
+
+    @CanvasField(postKey = "id")
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    @CanvasField(postKey = "title")
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    @CanvasField(postKey = "message")
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @CanvasField(postKey = "html_url")
+    public String getHtmlUrl() {
+        return htmlUrl;
+    }
+
+    public void setHtmlUrl(String htmlUrl) {
+        this.htmlUrl = htmlUrl;
+    }
+
+    @CanvasField(postKey = "posted_at")
+    public Date getPostedAt() {
+        return postedAt;
+    }
+
+    public void setPostedAt(Date postedAt) {
+        this.postedAt = postedAt;
+    }
+
+    @CanvasField(postKey = "last_reply_at")
+    public Date getLastReplyAt() {
+        return lastReplyAt;
+    }
+
+    public void setLastReplyAt(Date lastReplyAt) {
+        this.lastReplyAt = lastReplyAt;
+    }
+
+    @CanvasField(postKey = "require_initial_post")
+    public Boolean getRequireInitialPost() {
+        return requireInitialPost;
+    }
+
+    public void setRequireInitialPost(Boolean requireInitialPost) {
+        this.requireInitialPost = requireInitialPost;
+    }
+
+    @CanvasField(postKey = "user_can_see_posts")
+    public Boolean getUserCanSeePosts() {
+        return userCanSeePosts;
+    }
+
+    public void setUserCanSeePosts(Boolean userCanSeePosts) {
+        this.userCanSeePosts = userCanSeePosts;
+    }
+
+    @CanvasField(postKey = "discussion_subentry_count")
+    public Long getDiscussionSubentryCount() {
+        return discussionSubentryCount;
+    }
+
+    public void setDiscussionSubentryCount(Long discussionSubentryCount) {
+        this.discussionSubentryCount = discussionSubentryCount;
+    }
+
+    @CanvasField(postKey = "read_state")
+    public String getReadState() {
+        return readState;
+    }
+
+    public void setReadState(String readState) {
+        this.readState = readState;
+    }
+
+    @CanvasField(postKey = "unread_count")
+    public Long getUnreadCount() {
+        return unreadCount;
+    }
+
+    public void setUnreadCount(Long unreadCount) {
+        this.unreadCount = unreadCount;
+    }
+
+    @CanvasField(postKey = "subscribed")
+    public Boolean getSubscribed() {
+        return subscribed;
+    }
+
+    public void setSubscribed(Boolean subscribed) {
+        this.subscribed = subscribed;
+    }
+
+    @CanvasField(postKey = "subscription_hold")
+    public String getSubscriptionHold() {
+        return subscriptionHold;
+    }
+
+    public void setSubscriptionHold(String subscriptionHold) {
+        this.subscriptionHold = subscriptionHold;
+    }
+
+    @CanvasField(postKey = "assignment_id")
+    public Long getAssignmentId() {
+        return assignmentId;
+    }
+
+    public void setAssignmentId(Long assignmentId) {
+        this.assignmentId = assignmentId;
+    }
+
+    @CanvasField(postKey = "delayed_post_at")
+    public Date getDelayedPostAt() {
+        return delayedPostAt;
+    }
+
+    public void setDelayedPostAt(Date delayedPostAt) {
+        this.delayedPostAt = delayedPostAt;
+    }
+
+    @CanvasField(postKey = "published")
+    public Boolean getPublished() {
+        return published;
+    }
+
+    public void setPublished(Boolean published) {
+        this.published = published;
+    }
+
+    @CanvasField(postKey = "locked")
+    public Boolean getLocked() {
+        return locked;
+    }
+
+    public void setLocked(Boolean locked) {
+        this.locked = locked;
+    }
+
+    @CanvasField(postKey = "pinned")
+    public Boolean getPinned() {
+        return pinned;
+    }
+
+    public void setPinned(Boolean pinned) {
+        this.pinned = pinned;
+    }
+
+    @CanvasField(postKey = "locked_for_user")
+    public Boolean getLockedForUser() {
+        return lockedForUser;
+    }
+
+    public void setLockedForUser(Boolean lockedForUser) {
+        this.lockedForUser = lockedForUser;
+    }
+
+    @CanvasField(postKey = "lock_info")
+    public String getLockInfo() {
+        return lockInfo;
+    }
+
+    public void setLockInfo(String lockInfo) {
+        this.lockInfo = lockInfo;
+    }
+
+    @CanvasField(postKey = "lock_explanation")
+    public String getLockExplanation() {
+        return lockExplanation;
+    }
+
+    public void setLockExplanation(String lockExplanation) {
+        this.lockExplanation = lockExplanation;
+    }
+
+    @CanvasField(postKey = "user_name")
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+
+    @CanvasField(postKey = "root_topic_id")
+    public Long getRootTopicId() {
+        return rootTopicId;
+    }
+
+    public void setRootTopicId(Long rootTopicId) {
+        this.rootTopicId = rootTopicId;
+    }
+
+    @CanvasField(postKey = "podcast_url")
+    public String getPodcastUrl() {
+        return podcastUrl;
+    }
+
+    public void setPodcastUrl(String podcastUrl) {
+        this.podcastUrl = podcastUrl;
+    }
+
+    @CanvasField(postKey = "discussion_type")
+    public String getDiscussionType() {
+        return discussionType;
+    }
+
+    public void setDiscussionType(String discussionType) {
+        this.discussionType = discussionType;
+    }
+
+    @CanvasField(postKey = "group_category_id")
+    public Long getGroupCategoryId() {
+        return groupCategoryId;
+    }
+
+    public void setGroupCategoryId(Long groupCategoryId) {
+        this.groupCategoryId = groupCategoryId;
+    }
+
+    @CanvasField(postKey = "attachments")
+    public List<File> getAttachments() {
+        return attachments;
+    }
+
+    public void setAttachments(List<File> attachments) {
+        this.attachments = attachments;
+    }
+
+    @CanvasField(postKey = "allow_rating")
+    public Boolean getAllowRating() {
+        return allowRating;
+    }
+
+    public void setAllowRating(Boolean allowRating) {
+        this.allowRating = allowRating;
+    }
+
+    @CanvasField(postKey = "only_graders_can_rate")
+    public Boolean getOnlyGradersCanRate() {
+        return onlyGradersCanRate;
+    }
+
+    public void setOnlyGradersCanRate(Boolean onlyGradersCanRate) {
+        this.onlyGradersCanRate = onlyGradersCanRate;
+    }
+
+    @CanvasField(postKey = "sort_by_rating")
+    public Boolean getSortByRating() {
+        return sortByRating;
+    }
+
+    public void setSortByRating(Boolean sortByRating) {
+        this.sortByRating = sortByRating;
+    }
+}

--- a/src/main/java/edu/ksu/canvas/requestOptions/GetSingleDiscussionTopicOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/GetSingleDiscussionTopicOptions.java
@@ -1,0 +1,41 @@
+package edu.ksu.canvas.requestOptions;
+
+import java.util.List;
+
+public class GetSingleDiscussionTopicOptions extends BaseOptions {
+
+    public enum Include {
+        ALL_DATES, SECTIONS, SECTIONS_USER_COUNT, OVERRIDES
+    }
+
+    public enum IdType {
+        COURSES, GROUPS
+    }
+
+    private final String courseOrGroupId;
+    private final String discussionId;
+    private IdType idType;
+
+    public GetSingleDiscussionTopicOptions(String courseOrGroupId, String discussionId, IdType idType) {
+        this.courseOrGroupId = courseOrGroupId;
+        this.discussionId = discussionId;
+        this.idType = idType;
+    }
+
+    public String getCourseOrGroupId() {
+        return courseOrGroupId;
+    }
+
+    public String getDiscussionId() {
+        return discussionId;
+    }
+
+    public String getStringIdType() {
+        return idType.toString().toLowerCase();
+    }
+
+    public GetSingleDiscussionTopicOptions includes(List<Include> includes) {
+        addEnumList("include[]", includes);
+        return this;
+    }
+}

--- a/src/main/java/edu/ksu/canvas/requestOptions/ListDiscussionTopicsOptions.java
+++ b/src/main/java/edu/ksu/canvas/requestOptions/ListDiscussionTopicsOptions.java
@@ -1,0 +1,77 @@
+package edu.ksu.canvas.requestOptions;
+
+import java.util.List;
+
+public class ListDiscussionTopicsOptions extends BaseOptions {
+
+    public enum Include {
+        ALL_DATES, SECTIONS, SECTIONS_USER_COUNT, OVERRIDES
+    }
+
+    public enum OrderBy {
+        POSITION, RECENT_ACTIVITY, DATE
+    }
+
+    public enum Scope {
+        LOCKED, UNLOCKED, PINNED, UNPINNED
+    }
+
+    public enum FilterBy {
+        ALL, UNREAD
+    }
+
+    public enum IdType {
+        COURSES, GROUPS
+    }
+
+    private final String courseOrGroupId;
+    private final IdType idType;
+
+    public ListDiscussionTopicsOptions(String courseOrGroupId, IdType idType) {
+        this.courseOrGroupId = courseOrGroupId;
+        this.idType = idType;
+    }
+
+    public String getCourseOrGroupId() {
+        return courseOrGroupId;
+    }
+
+    public String getStringIdType() {
+        return idType.toString().toLowerCase();
+    }
+
+    public ListDiscussionTopicsOptions includes(List<Include> includes) {
+        addEnumList("include[]", includes);
+        return this;
+    }
+
+    public ListDiscussionTopicsOptions orderBy(OrderBy orderBy) {
+        addSingleItem("order_by", orderBy.toString());
+        return this;
+    }
+
+    public ListDiscussionTopicsOptions scope(Scope scope) {
+        addSingleItem("scope", scope.toString());
+        return this;
+    }
+
+    public ListDiscussionTopicsOptions onlyAnnouncements() {
+        addSingleItem("only_announcements", "true");
+        return this;
+    }
+
+    public ListDiscussionTopicsOptions filterBy(FilterBy filterBy) {
+        addSingleItem("filter_by", filterBy.toString());
+        return this;
+    }
+
+    public ListDiscussionTopicsOptions searchTerm(String search) {
+        addSingleItem("search_term", search);
+        return this;
+    }
+
+    public ListDiscussionTopicsOptions excludeContextModuleLockedTopics() {
+        addSingleItem("exclude_context_module_locked_topics", "true");
+        return this;
+    }
+}


### PR DESCRIPTION
Registers the ClassMap reflectively for less boilerplate.

Adds the API for DiscussionTopics (& announcements, _sort of_) https://canvas.instructure.com/doc/api/discussion_topics.html#DiscussionTopic

**Todo (as of writing):
- Javadoc everything in DiscussionTopic classes
- Write the Reader for DiscussionTopics**

This is my first time contributing, not sure if this project is still kept up with so I'm opening this PR. If it's still active and someone on the team is willing to merge this when I'm done, that'd be great. Otherwise I'll just keep my forked repo as-is since I'm a student and I'll really only ever being doing read operations on discussion topics.